### PR TITLE
refactor(rating-card): extract business logic to RatingCardService

### DIFF
--- a/projects/social_platform/src/app/ui/pages/courses/detail/info/info.component.ts
+++ b/projects/social_platform/src/app/ui/pages/courses/detail/info/info.component.ts
@@ -1,19 +1,9 @@
 /** @format */
 
-import {
-  AfterViewInit,
-  ChangeDetectorRef,
-  Component,
-  ElementRef,
-  HostListener,
-  inject,
-  OnInit,
-  ViewChild,
-} from "@angular/core";
+import { Component, HostListener, inject } from "@angular/core";
 import { RouterModule } from "@angular/router";
 import { ParseBreaksPipe, ParseLinksPipe } from "@corelib";
 import { IconComponent } from "@uilib";
-import { expandElement } from "@utils/expand-element";
 import { CommonModule } from "@angular/common";
 import { ModalComponent } from "@ui/primitives/modal/modal.component";
 import { ButtonComponent } from "@ui/primitives";
@@ -27,10 +17,7 @@ import { CourseAboutComponent } from "@ui/widgets/course-about/course-about.comp
   selector: "app-detail",
   standalone: true,
   imports: [
-    IconComponent,
     RouterModule,
-    ParseBreaksPipe,
-    ParseLinksPipe,
     CommonModule,
     SoonCardComponent,
     ModalComponent,
@@ -41,9 +28,7 @@ import { CourseAboutComponent } from "@ui/widgets/course-about/course-about.comp
   templateUrl: "./info.component.html",
   styleUrl: "./info.component.scss",
 })
-export class CourseInfoComponent implements OnInit, AfterViewInit {
-  @ViewChild("descEl") descEl?: ElementRef;
-
+export class CourseInfoComponent {
   protected appWidth = window.innerWidth;
 
   @HostListener("window:resize")
@@ -51,7 +36,6 @@ export class CourseInfoComponent implements OnInit, AfterViewInit {
     this.appWidth = window.innerWidth;
   }
 
-  private readonly cdRef = inject(ChangeDetectorRef);
   private readonly courseDetailUIInfoService = inject(CourseDetailUIInfoService);
 
   protected readonly courseStructure = this.courseDetailUIInfoService.courseStructure;
@@ -59,20 +43,4 @@ export class CourseInfoComponent implements OnInit, AfterViewInit {
   protected readonly courseModules = this.courseDetailUIInfoService.courseModules;
   protected readonly isCompleteModule = this.courseDetailUIInfoService.isCompleteModule;
   protected readonly isCourseCompleted = this.courseDetailUIInfoService.isCourseCompleted;
-
-  protected descriptionExpandable?: boolean;
-  protected readFullDescription!: boolean;
-
-  ngOnInit(): void {}
-
-  ngAfterViewInit(): void {
-    const descElement = this.descEl?.nativeElement;
-    this.descriptionExpandable = descElement?.clientHeight < descElement?.scrollHeight;
-    this.cdRef.detectChanges();
-  }
-
-  onExpandDescription(elem: HTMLElement, expandedClass: string, isExpanded: boolean): void {
-    expandElement(elem, expandedClass, isExpanded);
-    this.readFullDescription = !isExpanded;
-  }
 }

--- a/projects/social_platform/src/app/ui/pages/feed/open-vacancy/open-vacancy.component.html
+++ b/projects/social_platform/src/app/ui/pages/feed/open-vacancy/open-vacancy.component.html
@@ -21,7 +21,7 @@
         {{ project.name | truncate: 30 }}
       </p>
 
-      @if (industryRepository.getOne(project.industry); as industry) {
+      @if (industryRepositoryGetOne(project.industry); as industry) {
       <app-tag class="card__industry" color="complete">
         {{ industry.name }}
       </app-tag>
@@ -59,7 +59,7 @@
           }
         </div>
         } @if (skillsLength > 8) {
-        <div class="read-more text-body-10" (click)="readFullSkills = !readFullSkills">
+        <div class="read-more text-body-10" (click)="toggleSkills()">
           {{ readFullSkills ? "cкрыть" : "подробнее" }}
         </div>
         } }
@@ -73,12 +73,9 @@
             #descEl
             [innerHTML]="vacancy.description | parseLinks | parseBreaks"
           ></p>
-          @if (descriptionExpandable) {
-          <div
-            class="read-more text-body-10"
-            (click)="onExpandDescription(descEl, 'expanded', readFullDescription)"
-          >
-            {{ readFullDescription ? "скрыть" : "подробнее" }}
+          @if (descriptionExpandable()) {
+          <div class="read-more text-body-10" (click)="onExpandDescription(descEl)">
+            {{ readFullDescription() ? "скрыть" : "подробнее" }}
           </div>
           }
         </div>

--- a/projects/social_platform/src/app/ui/pages/feed/open-vacancy/open-vacancy.component.ts
+++ b/projects/social_platform/src/app/ui/pages/feed/open-vacancy/open-vacancy.component.ts
@@ -3,9 +3,9 @@
 import {
   AfterViewInit,
   ChangeDetectionStrategy,
-  ChangeDetectorRef,
   Component,
   ElementRef,
+  inject,
   Input,
   ViewChild,
 } from "@angular/core";
@@ -14,11 +14,11 @@ import { ButtonComponent } from "@ui/primitives";
 import { Router, RouterLink } from "@angular/router";
 import { TagComponent } from "@ui/primitives/tag/tag.component";
 import { Vacancy } from "@domain/vacancy/vacancy.model";
-import { expandElement } from "@utils/expand-element";
 import { AvatarComponent } from "@ui/primitives/avatar/avatar.component";
 import { TruncatePipe, DayjsPipe, ParseBreaksPipe, ParseLinksPipe } from "@corelib";
 import { AppRoutes } from "@api/paths/app-routes";
 import { IndustryRepositoryPort } from "@domain/industry/ports/industry.repository.port";
+import { ExpandService } from "@api/expand/expand.service";
 
 /** Карточка вакансии в ленте с поддержкой разворачивания контента. */
 @Component({
@@ -38,48 +38,40 @@ import { IndustryRepositoryPort } from "@domain/industry/ports/industry.reposito
   templateUrl: "./open-vacancy.component.html",
   styleUrl: "./open-vacancy.component.scss",
   changeDetection: ChangeDetectionStrategy.OnPush,
+  providers: [ExpandService],
 })
 export class OpenVacancyComponent implements AfterViewInit {
   @Input() feedItem!: Vacancy;
+
+  private readonly expandService = inject(ExpandService);
   protected readonly AppRoutes = AppRoutes;
+  private readonly industryRepository = inject(IndustryRepositoryPort);
 
-  @ViewChild("skillsEl") skillsEl?: ElementRef;
-  @ViewChild("descEl") descEl?: ElementRef;
+  @ViewChild("skillsEl") private skillsEl?: ElementRef;
+  @ViewChild("descEl") private descEl?: ElementRef;
 
-  constructor(
-    public readonly router: Router,
-    private readonly cdRef: ChangeDetectorRef,
-    public readonly industryRepository: IndustryRepositoryPort
-  ) {}
+  readFullSkills = false;
+
+  protected readonly descriptionExpandable = this.expandService.descriptionExpandable;
+  protected readonly readFullDescription = this.expandService.readFullDescription;
+  protected readonly industryRepositoryGetOne = (id: number) => this.industryRepository.getOne(id);
 
   ngAfterViewInit(): void {
-    // Проверяем, превышает ли описание доступную высоту
-    const descElement = this.descEl?.nativeElement;
-    this.descriptionExpandable = descElement?.clientHeight < descElement?.scrollHeight;
-
-    // Проверяем, превышает ли список навыков доступную высоту
-    const skillsElement = this.skillsEl?.nativeElement;
-    this.skillsExpandable = skillsElement?.clientHeight < skillsElement?.scrollHeight;
-
-    // Обновляем UI после изменения флагов
-    this.cdRef.detectChanges();
+    setTimeout(() => {
+      this.expandService.checkExpandable("description", true, this.descEl);
+    });
   }
 
-  // Флаги для определения возможности развертывания контента
-  descriptionExpandable!: boolean; // Можно ли развернуть описание
-  skillsExpandable!: boolean; // Можно ли развернуть список навыков
-
-  // Состояние развертывания контента
-  readFullDescription = false; // Развернуто ли описание
-  readFullSkills = false; // Развернут ли список навыков
-
-  onExpandDescription(elem: HTMLElement, expandedClass: string, isExpanded: boolean): void {
-    expandElement(elem, expandedClass, isExpanded);
-    this.readFullDescription = !isExpanded;
+  protected onExpandDescription(elem: HTMLElement): void {
+    this.expandService.onExpand(
+      "description",
+      elem,
+      "expanded",
+      this.expandService.readFullDescription()
+    );
   }
 
-  onExpandSkills(elem: HTMLElement, expandedClass: string, isExpanded: boolean): void {
-    expandElement(elem, expandedClass, isExpanded);
-    this.readFullSkills = !isExpanded;
+  protected toggleSkills(): void {
+    this.readFullSkills = !this.readFullSkills;
   }
 }

--- a/projects/social_platform/src/app/ui/pages/program/detail/list/rating-card/rating-card.component.html
+++ b/projects/social_platform/src/app/ui/pages/program/detail/list/rating-card/rating-card.component.html
@@ -17,7 +17,7 @@
             <p class="text-body-12 card__naming--text">{{ project.name | truncate: 15 }}</p>
           </a>
 
-          @if (industryRepository.getOne(project.industry); as industry) {
+          @if (industryRepositoryGetOne(project.industry); as industry) {
           <app-tag class="card__industry" color="complete">
             {{ industry.name }}
           </app-tag>
@@ -49,10 +49,7 @@
       <div class="text-body-10 about__text">
         <p #descEl [innerHTML]="project.description | parseLinks | parseBreaks"></p>
         @if (descriptionExpandable()) {
-        <div
-          class="about__read-full text-body-10"
-          (click)="expandDescription(descEl, 'expanded', readFullDescription())"
-        >
+        <div class="about__read-full text-body-10" (click)="onExpandDescription(descEl)">
           {{ readFullDescription() ? "скрыть" : "подробнее" }}
         </div>
         }
@@ -74,36 +71,36 @@
       </div>
       <app-project-rating
         [criteria]="project.criterias"
-        [formControl]="form"
+        [formControl]="form()"
         [currentUserId]="profile()!.id"
         [disabled]="
-          (projectRated() || projectConfirmed()) && isRatedByCurrentUser && !programDateFinished()
+          (projectRated() || projectConfirmed()) && isRatedByCurrentUser() && !programDateFinished()
         "
       ></app-project-rating>
-      @if (form | controlError: "required"; as error) {
+      @if (form() | controlError: "required"; as error) {
       <div class="text-body-10 error">
         {{ error }}
       </div>
       }
     </div>
 
-    @if (showRatingForm || showRatedStatus || showConfirmedState) {
+    @if (showRatingForm() || showRatedStatus() || showConfirmedState()) {
     <div class="card__rated">
       <app-button
         style="flex-grow: 1"
         customTypographyClass="text-body-12"
         size="big"
         [loader]="submitLoading() || confirmLoading()"
-        [disabled]="isButtonDisabled"
-        [style.opacity]="buttonOpacity"
-        [color]="buttonColor"
-        [title]="buttonTooltip"
+        [disabled]="isButtonDisabled()"
+        [style.opacity]="buttonOpacity()"
+        [color]="buttonColor()"
+        [title]="buttonTooltip()"
         (click)="handleRateButtonClick()"
       >
-        {{ rateButtonText }}
+        {{ rateButtonText() }}
       </app-button>
 
-      @if (showEditButton) {
+      @if (showEditButton()) {
       <app-button
         appearance="outline"
         size="small"
@@ -117,10 +114,7 @@
     </div>
     }
 
-    <app-modal
-      [open]="showConfirmRateModal()"
-      (openChange)="showConfirmRateModal.set(!showConfirmRateModal())"
-    >
+    <app-modal [open]="showConfirmRateModal()" (openChange)="toggleConfirmRateModal()">
       <div class="cancel">
         <div class="cancel__top">
           <p class="cancel__title text-body-14">подтвердите оценку</p>
@@ -135,7 +129,7 @@
           @if (showConfirmRateModal()) {
           <app-project-rating
             [criteria]="project.criterias"
-            [formControl]="form"
+            [formControl]="form()"
             [disabled]="true"
           ></app-project-rating>
           }
@@ -156,7 +150,7 @@
             class="cancel__button"
             appearance="outline"
             customTypographyClass="text-body-12"
-            (click)="showConfirmRateModal.set(false)"
+            (click)="closeConfirmRateModal()"
           >
             изменить оценку
           </app-button>

--- a/projects/social_platform/src/app/ui/pages/program/detail/list/rating-card/rating-card.component.ts
+++ b/projects/social_platform/src/app/ui/pages/program/detail/list/rating-card/rating-card.component.ts
@@ -2,13 +2,9 @@
 
 import {
   AfterViewInit,
-  ChangeDetectorRef,
   Component,
   ElementRef,
   Input,
-  OnDestroy,
-  OnInit,
-  signal,
   ViewChild,
   inject,
   ChangeDetectionStrategy,
@@ -16,17 +12,6 @@ import {
 import { ButtonComponent, IconComponent } from "@ui/primitives";
 import { AvatarComponent } from "@ui/primitives/avatar/avatar.component";
 import { CommonModule } from "@angular/common";
-import { expandElement } from "@utils/expand-element";
-import {
-  debounceTime,
-  filter,
-  finalize,
-  fromEvent,
-  map,
-  Observable,
-  Subscription,
-  tap,
-} from "rxjs";
 import { BreakpointObserver } from "@angular/cdk/layout";
 import { ProjectRatingComponent } from "./project-rating/project-rating.component";
 import { FormControl, ReactiveFormsModule } from "@angular/forms";
@@ -34,14 +19,12 @@ import { RouterLink } from "@angular/router";
 import { TagComponent } from "@ui/primitives/tag/tag.component";
 import { ModalComponent } from "@ui/primitives/modal/modal.component";
 import { TruncatePipe, ControlErrorPipe, ParseBreaksPipe, ParseLinksPipe } from "@corelib";
-import { HttpResponse } from "@angular/common/http";
 import { ProjectRate } from "@domain/project/project-rate";
-import { ProgramDetailMainUIInfoService } from "@api/program/facades/detail/ui/program-detail-main-ui-info.service";
-import { LoggerService } from "@core/lib/services/logger/logger.service";
-import { RateProjectUseCase } from "@api/program/use-cases/rate-project.use-case";
 import { AppRoutes } from "@api/paths/app-routes";
 import { IndustryRepositoryPort } from "@domain/industry/ports/industry.repository.port";
-import { ProfileInfoService } from "@api/profile/facades/profile-info.service";
+import { RatingCardService } from "./services/rating-card.service";
+import { ExpandService } from "@api/expand/expand.service";
+import { map } from "rxjs";
 
 /** Карточка оценки проекта экспертом: форма с критериями, навигация, переоценка. */
 @Component({
@@ -65,292 +48,98 @@ import { ProfileInfoService } from "@api/profile/facades/profile-info.service";
     TruncatePipe,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
+  providers: [RatingCardService, ExpandService],
 })
-export class RatingCardComponent implements OnInit, AfterViewInit, OnDestroy {
-  private readonly logger = inject(LoggerService);
-  protected readonly AppRoutes = AppRoutes;
-  protected industryRepository = inject(IndustryRepositoryPort);
-  private readonly rateProjectUseCase = inject(RateProjectUseCase);
-  private readonly programDetailMainUIInfoService = inject(ProgramDetailMainUIInfoService);
-  private readonly profileInfoService = inject(ProfileInfoService);
+export class RatingCardComponent implements AfterViewInit {
+  private readonly ratingCardService = inject(RatingCardService);
+  private readonly expandService = inject(ExpandService);
   private readonly breakpointObserver = inject(BreakpointObserver);
-  private readonly cdRef = inject(ChangeDetectorRef);
+
+  protected readonly AppRoutes = AppRoutes;
+  private readonly industryRepository = inject(IndustryRepositoryPort);
+
+  @ViewChild("descEl") private descEl?: ElementRef;
 
   @Input({ required: true }) set project(proj: ProjectRate | null) {
-    if (!proj) return;
-    this._project.set(proj);
+    this.ratingCardService.initProject(proj);
   }
 
   get project(): ProjectRate | null {
-    return this._project();
+    return this.ratingCardService.project();
   }
 
-  @ViewChild("descEl") descEl?: ElementRef;
-
-  _project = signal<ProjectRate | null>(null);
-  _currentIndex = signal<number>(0);
-  _projects = signal<ProjectRate[]>([]);
-
-  protected readonly profile = this.profileInfoService.profile;
-
-  form = new FormControl();
-
-  submitLoading = signal(false);
-  confirmLoading = signal(false);
-
-  readFullDescription = signal(false);
-
-  descriptionExpandable = signal(false);
-
-  projectRated = signal(false);
-
-  projectConfirmed = signal(false);
-
-  showConfirmRateModal = signal(false);
-
-  locallyRatedByCurrentUser = signal(false);
-
-  isProjectCriterias = signal(0);
-  ratedCount = signal(0);
-
-  readonly programDateFinished = this.programDetailMainUIInfoService.registerDateExpired;
-  readonly program = this.programDetailMainUIInfoService.program;
-
-  desktopMode$: Observable<boolean> = this.breakpointObserver
+  protected readonly desktopMode$ = this.breakpointObserver
     .observe("(min-width: 1000px)")
     .pipe(map(result => result.matches));
 
-  subscriptions$ = signal<Subscription[]>([]);
+  protected readonly descriptionExpandable = this.expandService.descriptionExpandable;
+  protected readonly readFullDescription = this.expandService.readFullDescription;
 
-  ngOnInit(): void {
-    if (this.project) {
-      const isScored = this.project?.scored || false;
-      this.projectConfirmed.set(isScored);
-      this.projectRated.set(isScored);
-      this.ratedCount.set(this.project.ratedCount);
-    }
-  }
+  protected readonly ratedCount = this.ratingCardService.ratedCount;
+  protected readonly isProjectCriterias = this.ratingCardService.isProjectCriterias;
+  protected readonly form = this.ratingCardService.form;
+  protected readonly profile = this.ratingCardService.profile;
+  protected readonly projectRated = this.ratingCardService.projectRated;
+  protected readonly projectConfirmed = this.ratingCardService.projectConfirmed;
+  protected readonly isRatedByCurrentUser = this.ratingCardService.isRatedByCurrentUser;
+  protected readonly programDateFinished = this.ratingCardService.programDateFinished;
+  protected readonly showRatingForm = this.ratingCardService.showRatingForm;
+  protected readonly showRatedStatus = this.ratingCardService.showRatedStatus;
+  protected readonly showConfirmedState = this.ratingCardService.showConfirmedState;
+  protected readonly submitLoading = this.ratingCardService.submitLoading;
+  protected readonly confirmLoading = this.ratingCardService.confirmLoading;
+  protected readonly isButtonDisabled = this.ratingCardService.isButtonDisabled;
+  protected readonly buttonOpacity = this.ratingCardService.buttonOpacity;
+  protected readonly buttonColor = this.ratingCardService.buttonColor;
+  protected readonly buttonTooltip = this.ratingCardService.buttonTooltip;
+  protected readonly rateButtonText = this.ratingCardService.rateButtonText;
+  protected readonly showEditButton = this.ratingCardService.showEditButton;
+  protected readonly showConfirmRateModal = this.ratingCardService.showConfirmRateModal;
+
+  protected readonly industryRepositoryGetOne = (id: number) => this.industryRepository.getOne(id);
 
   ngAfterViewInit(): void {
-    if (this.project) {
-      this.isProjectCriterias.set(
-        this.project?.criterias.filter(criteria => !(criteria.type === "str")).length
-      );
-    }
-
-    const descElement = this.descEl?.nativeElement;
-    this.descriptionExpandable.set(descElement?.clientHeight < descElement?.scrollHeight);
-    this.cdRef.detectChanges();
-
-    const resizeSub$ = fromEvent(window, "resize")
-      .pipe(debounceTime(50))
-      .subscribe(() => {
-        this.descriptionExpandable.set(descElement?.clientHeight < descElement?.scrollHeight);
-      });
-
-    this.subscriptions$().push(resizeSub$);
+    setTimeout(() => {
+      this.expandService.checkExpandable("description", true, this.descEl);
+    });
   }
 
-  ngOnDestroy(): void {
-    this.subscriptions$().forEach($ => $.unsubscribe());
+  protected onExpandDescription(elem: HTMLElement): void {
+    this.expandService.onExpand(
+      "description",
+      elem,
+      "expanded",
+      this.expandService.readFullDescription()
+    );
   }
 
-  expandDescription(elem: HTMLElement, expandedClass: string, isExpanded: boolean): void {
-    expandElement(elem, expandedClass, isExpanded);
-    this.readFullDescription.set(!isExpanded);
-  }
-
-  confirmRateProject(): void {
-    this.form.markAsTouched();
-    if (this.form.invalid) return;
-
-    const fv = this.form.getRawValue();
-    const project = this.project as ProjectRate;
-
-    this.submitLoading.set(true);
-
-    this.rateProjectUseCase
-      .execute(project.id, project.criterias, fv)
-      .pipe(finalize(() => this.submitLoading.set(false)))
-      .subscribe({
-        next: result => {
-          if (!result.ok) {
-            if (result.error.cause instanceof HttpResponse) {
-              if (result.error.cause.status === 400) {
-                this.logger.error("Ошибка: достигнут максимальный лимит оценок");
-              }
-            }
-            return;
-          }
-
-          const profile = this.profile();
-          const project = this.project as ProjectRate;
-
-          this.locallyRatedByCurrentUser.set(true);
-          this.projectRated.set(true);
-          this.projectConfirmed.set(true);
-
-          let isFirstTimeRating = false;
-
-          if (profile) {
-            if (!Array.isArray(project.ratedExperts)) {
-              project.ratedExperts = [];
-            }
-
-            // Проверяем, первый ли раз пользователь оценивает
-            if (!project.ratedExperts.some(user => user.id === profile.id)) {
-              project.ratedExperts = [...project.ratedExperts, profile];
-              isFirstTimeRating = true;
-            }
-          }
-
-          // Увеличиваем счетчик только при первой оценке
-          if (isFirstTimeRating) {
-            this.ratedCount.update(count => count + 1);
-          }
-
-          this._project.set({ ...project });
-          this.showConfirmRateModal.set(false);
-        },
-      });
-  }
-
-  /** Сбрасывает статусы для переоценки (не удаляет из списка оценивших). */
-  redoRating(): void {
-    this.projectRated.set(false);
-    this.projectConfirmed.set(false);
-    // locallyRatedByCurrentUser остается true, так как пользователь уже в списке оценивших
-    // После сброса статусов кнопка станет "оценить проект" и откроет модалку
-  }
-
-  openPresentation(url: string) {
+  protected openPresentation(url: string): void {
     if (url) {
       window.open(url, "_blank");
     }
   }
 
-  get canEdit(): boolean {
-    return !this.programDateFinished();
-  }
-
-  get isCurrentUserExpert(): boolean {
-    const currentProfile = this.profile();
-    const project = this.project;
-
-    if (!currentProfile || !project) return false;
-
-    const isExpertFromBackend =
-      !!project.scoredExpertId && project.scoredExpertId === currentProfile.id;
-
-    const isExpertLocally = this.locallyRatedByCurrentUser();
-
-    return isExpertFromBackend || isExpertLocally;
-  }
-
-  /** Проверяет, может ли пользователь оценить проект (программа не завершена + лимит не достигнут). */
-  get canRate(): boolean {
-    if (this.programDateFinished()) return false;
-
-    // Если лимит достигнут, но пользователь уже оценивал - разрешаем переоценку
-    if (this.isLimitReached && !this.userRatedThisProject) return false;
-
-    return true;
-  }
-
-  get rateButtonText(): string {
-    if (this.programDateFinished()) return "программа завершена";
-    if (this.projectConfirmed() && this.userRatedThisProject) return "проект оценен";
-    if (this.isLimitReached && !this.userRatedThisProject) return "лимит оценок достигнут";
-
-    return "оценить проект";
-  }
-
-  get showRatingForm(): boolean {
-    return !this.projectRated() && this.canEdit;
-  }
-
-  get showRatedStatus(): boolean {
-    return this.projectRated() || this.projectConfirmed();
-  }
-
-  get showEditButton(): boolean {
-    return this.projectConfirmed() && !this.programDateFinished() && this.userRatedThisProject;
-  }
-
-  /** Модалка открывается только для первой оценки или переоценки. */
-  get canOpenModal(): boolean {
-    // Если проект подтвержден и оценен - НЕ открываем модалку по клику на кнопку
-    if (this.projectConfirmed() && this.userRatedThisProject) return false;
-
-    // В остальных случаях проверяем canRate
-    return this.canRate;
-  }
-
-  get userRatedThisProject(): boolean {
-    const profile = this.profile();
-    const project = this.project;
-
-    if (!profile || !project) return false;
-
-    return (
-      this.locallyRatedByCurrentUser() ||
-      (Array.isArray(project.ratedExperts) && this.isRatedByCurrentUser)
-    );
-  }
-
-  get isRatedByCurrentUser(): boolean {
-    const currentUser = this.profile();
-    const project = this.project;
-
-    if (!currentUser || !project) {
-      return false;
-    }
-
-    return project.ratedExperts.some(user => user.id === currentUser.id);
-  }
-
-  get isButtonDisabled(): boolean {
-    if (this.isLimitReached && !this.userRatedThisProject) return true;
-    if (this.programDateFinished()) return true;
-    return !this.canRate;
-  }
-
-  get buttonColor(): "green" | "primary" {
-    if (this.userRatedThisProject) return "green";
-    return "primary";
-  }
-
-  get buttonOpacity(): string {
-    return this.isButtonDisabled ? "0.5" : "1";
-  }
-
-  get isLimitReached(): boolean {
-    return !!this.project && this.project.ratedCount >= this.project.maxRates;
-  }
-
-  get showConfirmedState(): boolean {
-    return (
-      (this.projectConfirmed() && !this.canEdit) ||
-      (this.isLimitReached && !this.userRatedThisProject)
-    );
-  }
-
-  handleRateButtonClick(): void {
-    if (this.canOpenModal) {
-      this.showConfirmRateModal.set(true);
+  protected handleRateButtonClick(): void {
+    if (this.ratingCardService.canOpenModal()) {
+      this.ratingCardService.showConfirmRateModal.set(true);
     }
   }
 
-  get buttonTooltip(): string {
-    if (this.programDateFinished()) return "Программа завершена";
-    if (this.isLimitReached && !this.userRatedThisProject) {
-      return "Достигнут максимальный лимит оценок";
-    }
-    if (this.userRatedThisProject) return "Нажмите для переоценки";
-    return "Нажмите для оценки проекта";
+  protected confirmRateProject(): void {
+    this.ratingCardService.form().markAsTouched();
+    if (this.ratingCardService.form().invalid) return;
+    this.ratingCardService.confirmRateProject();
   }
 
-  get isModalFormDisabled(): boolean {
-    return true; // Всегда disabled в модалке для подтверждения
+  protected redoRating(): void {
+    this.ratingCardService.redoRating();
+  }
+
+  protected toggleConfirmRateModal(): void {
+    this.ratingCardService.showConfirmRateModal.set(!this.ratingCardService.showConfirmRateModal());
+  }
+
+  protected closeConfirmRateModal(): void {
+    this.ratingCardService.showConfirmRateModal.set(false);
   }
 }

--- a/projects/social_platform/src/app/ui/pages/program/detail/list/rating-card/services/rating-card.service.ts
+++ b/projects/social_platform/src/app/ui/pages/program/detail/list/rating-card/services/rating-card.service.ts
@@ -1,0 +1,194 @@
+/** @format */
+
+import { computed, inject, Injectable, signal } from "@angular/core";
+import { RateProjectUseCase } from "@api/program/use-cases/rate-project.use-case";
+import { ProgramDetailMainUIInfoService } from "@api/program/facades/detail/ui/program-detail-main-ui-info.service";
+import { ProfileInfoService } from "@api/profile/facades/profile-info.service";
+import { ProjectRate } from "@domain/project/project-rate";
+import { LoggerService } from "@core/lib/services/logger/logger.service";
+import { HttpResponse } from "@angular/common/http";
+import { finalize } from "rxjs";
+import { FormControl } from "@angular/forms";
+
+/** Сервис бизнес-логики карточки оценки проекта экспертом. */
+@Injectable()
+export class RatingCardService {
+  private readonly rateProjectUseCase = inject(RateProjectUseCase);
+  private readonly programDetailMainUIInfoService = inject(ProgramDetailMainUIInfoService);
+  private readonly profileInfoService = inject(ProfileInfoService);
+  private readonly logger = inject(LoggerService);
+
+  readonly profile = this.profileInfoService.profile;
+  readonly programDateFinished = this.programDetailMainUIInfoService.registerDateExpired;
+  readonly program = this.programDetailMainUIInfoService.program;
+
+  readonly project = signal<ProjectRate | null>(null);
+  readonly form = signal<FormControl>(new FormControl());
+
+  readonly submitLoading = signal(false);
+  readonly confirmLoading = signal(false);
+  readonly showConfirmRateModal = signal(false);
+  readonly locallyRatedByCurrentUser = signal(false);
+  readonly projectRated = signal(false);
+  readonly projectConfirmed = signal(false);
+  readonly ratedCount = signal(0);
+
+  readonly isProjectCriterias = computed(() => {
+    const p = this.project();
+    if (!p) return 0;
+    return p.criterias.filter(c => c.type !== "str").length;
+  });
+
+  readonly isCurrentUserExpert = computed(() => {
+    const currentProfile = this.profile();
+    const p = this.project();
+    if (!currentProfile || !p) return false;
+
+    const isExpertFromBackend = !!p.scoredExpertId && p.scoredExpertId === currentProfile.id;
+
+    return isExpertFromBackend || this.locallyRatedByCurrentUser();
+  });
+
+  readonly isRatedByCurrentUser = computed(() => {
+    const currentUser = this.profile();
+    const p = this.project();
+    if (!currentUser || !p) return false;
+
+    return p.ratedExperts.some(user => user.id === currentUser.id);
+  });
+
+  readonly userRatedThisProject = computed(() => {
+    return (
+      this.locallyRatedByCurrentUser() ||
+      (this.project()?.ratedExperts && this.isRatedByCurrentUser())
+    );
+  });
+
+  readonly isLimitReached = computed(() => {
+    const p = this.project();
+    return !!p && p.ratedCount >= p.maxRates;
+  });
+
+  readonly canEdit = computed(() => !this.programDateFinished());
+
+  readonly canRate = computed(() => {
+    if (this.programDateFinished()) return false;
+    if (this.isLimitReached() && !this.userRatedThisProject()) return false;
+    return true;
+  });
+
+  readonly canOpenModal = computed(() => {
+    if (this.projectConfirmed() && this.userRatedThisProject()) return false;
+    return this.canRate();
+  });
+
+  readonly rateButtonText = computed(() => {
+    if (this.programDateFinished()) return "программа завершена";
+    if (this.projectConfirmed() && this.userRatedThisProject()) return "проект оценен";
+    if (this.isLimitReached() && !this.userRatedThisProject()) return "лимит оценок достигнут";
+    return "оценить проект";
+  });
+
+  readonly showRatingForm = computed(() => !this.projectRated() && this.canEdit());
+
+  readonly showRatedStatus = computed(() => this.projectRated() || this.projectConfirmed());
+
+  readonly showEditButton = computed(
+    () => this.projectConfirmed() && !this.programDateFinished() && this.userRatedThisProject()
+  );
+
+  readonly isButtonDisabled = computed(() => {
+    if (this.isLimitReached() && !this.userRatedThisProject()) return true;
+    if (this.programDateFinished()) return true;
+    return !this.canRate();
+  });
+
+  readonly buttonColor = computed<"green" | "primary">(() =>
+    this.userRatedThisProject() ? "green" : "primary"
+  );
+
+  readonly buttonOpacity = computed(() => (this.isButtonDisabled() ? "0.5" : "1"));
+
+  readonly showConfirmedState = computed(
+    () =>
+      (this.projectConfirmed() && !this.canEdit()) ||
+      (this.isLimitReached() && !this.userRatedThisProject())
+  );
+
+  readonly buttonTooltip = computed(() => {
+    if (this.programDateFinished()) return "Программа завершена";
+    if (this.isLimitReached() && !this.userRatedThisProject())
+      return "Достигнут максимальный лимит оценок";
+    if (this.userRatedThisProject()) return "Нажмите для переоценки";
+    return "Нажмите для оценки проекта";
+  });
+
+  readonly isModalFormDisabled = computed(() => true);
+
+  /** Инициализация начального состояния проекта. */
+  initProject(project: ProjectRate | null): void {
+    if (!project) return;
+    this.project.set(project);
+    const isScored = project.scored || false;
+    this.projectConfirmed.set(isScored);
+    this.projectRated.set(isScored);
+    this.ratedCount.set(project.ratedCount);
+  }
+
+  /** Подтверждение оценки проекта. */
+  confirmRateProject(): void {
+    const fv = this.form().getRawValue();
+    const p = this.project() as ProjectRate;
+
+    this.submitLoading.set(true);
+
+    this.rateProjectUseCase
+      .execute(p.id, p.criterias, fv)
+      .pipe(finalize(() => this.submitLoading.set(false)))
+      .subscribe({
+        next: result => {
+          if (!result.ok) {
+            if (result.error.cause instanceof HttpResponse) {
+              if (result.error.cause.status === 400) {
+                this.logger.error("Ошибка: достигнут максимальный лимит оценок");
+              }
+            }
+            return;
+          }
+
+          const profile = this.profile();
+          const proj = this.project() as ProjectRate;
+
+          this.locallyRatedByCurrentUser.set(true);
+          this.projectRated.set(true);
+          this.projectConfirmed.set(true);
+
+          let isFirstTimeRating = false;
+
+          if (profile) {
+            if (!Array.isArray(proj.ratedExperts)) {
+              proj.ratedExperts = [];
+            }
+
+            if (!proj.ratedExperts.some(user => user.id === profile.id)) {
+              proj.ratedExperts = [...proj.ratedExperts, profile];
+              isFirstTimeRating = true;
+            }
+          }
+
+          if (isFirstTimeRating) {
+            this.ratedCount.update(count => count + 1);
+          }
+
+          this.project.set({ ...proj });
+          this.showConfirmRateModal.set(false);
+        },
+      });
+  }
+
+  /** Сброс статусов для переоценки. */
+  redoRating(): void {
+    this.projectRated.set(false);
+    this.projectConfirmed.set(false);
+  }
+}

--- a/projects/social_platform/src/app/ui/widgets/course-about/course-about.component.html
+++ b/projects/social_platform/src/app/ui/widgets/course-about/course-about.component.html
@@ -8,9 +8,9 @@
   @if (description) {
   <div class="text-body-10 about__text">
     <p #descEl [innerHTML]="description | parseLinks | parseBreaks"></p>
-    @if (descriptionExpandable) {
-    <div class="read-more" (click)="onExpandDescription(descEl, 'expanded', readFullDescription)">
-      {{ readFullDescription ? "cкрыть" : "подробнее" }}
+    @if (descriptionExpandable()) {
+    <div class="read-more" (click)="onExpandDescription(descEl)">
+      {{ readFullDescription() ? "cкрыть" : "подробнее" }}
     </div>
     }
   </div>

--- a/projects/social_platform/src/app/ui/widgets/course-about/course-about.component.ts
+++ b/projects/social_platform/src/app/ui/widgets/course-about/course-about.component.ts
@@ -1,17 +1,9 @@
 /** @format */
 
-import {
-  AfterViewInit,
-  ChangeDetectorRef,
-  Component,
-  ElementRef,
-  inject,
-  Input,
-  ViewChild,
-} from "@angular/core";
+import { AfterViewInit, Component, ElementRef, inject, Input, ViewChild } from "@angular/core";
 import { IconComponent } from "@uilib";
 import { ParseBreaksPipe, ParseLinksPipe } from "@corelib";
-import { expandElement } from "@utils/expand-element";
+import { ExpandService } from "@api/expand/expand.service";
 
 /** Виджет «о курсе»: описание курса в модалке/блоке. */
 @Component({
@@ -20,24 +12,29 @@ import { expandElement } from "@utils/expand-element";
   styleUrl: "./course-about.component.scss",
   standalone: true,
   imports: [IconComponent, ParseBreaksPipe, ParseLinksPipe],
+  providers: [ExpandService],
 })
 export class CourseAboutComponent implements AfterViewInit {
   @Input({ required: true }) description!: string;
-  @ViewChild("descEl") descEl?: ElementRef;
+  @ViewChild("descEl") private descEl?: ElementRef;
 
-  private readonly cdRef = inject(ChangeDetectorRef);
+  private readonly expandService = inject(ExpandService);
 
-  descriptionExpandable = false;
-  readFullDescription = false;
+  protected readonly descriptionExpandable = this.expandService.descriptionExpandable;
+  protected readonly readFullDescription = this.expandService.readFullDescription;
 
   ngAfterViewInit(): void {
-    const el = this.descEl?.nativeElement;
-    this.descriptionExpandable = el?.clientHeight < el?.scrollHeight;
-    this.cdRef.detectChanges();
+    setTimeout(() => {
+      this.expandService.checkExpandable("description", true, this.descEl);
+    });
   }
 
-  onExpandDescription(elem: HTMLElement, expandedClass: string, isExpanded: boolean): void {
-    expandElement(elem, expandedClass, isExpanded);
-    this.readFullDescription = !isExpanded;
+  protected onExpandDescription(elem: HTMLElement): void {
+    this.expandService.onExpand(
+      "description",
+      elem,
+      "expanded",
+      this.expandService.readFullDescription()
+    );
   }
 }

--- a/projects/social_platform/src/app/ui/widgets/news-card/news-card.component.html
+++ b/projects/social_platform/src/app/ui/widgets/news-card/news-card.component.html
@@ -63,12 +63,9 @@
     ></app-file-upload-item>
     }
   </ul>
-  } @if (newsTextExpandable && !editMode) {
-  <div
-    class="read-more text-body-10"
-    (click)="onExpandNewsText(newsTextEl?.nativeElement, 'expanded', readMore)"
-  >
-    {{ readMore ? "скрыть" : "подробнее" }}
+  } @if (descriptionExpandable() && !editMode) {
+  <div class="read-more text-body-10" (click)="onExpandNewsText(newsTextEl?.nativeElement)">
+    {{ readFullDescription() ? "скрыть" : "подробнее" }}
   </div>
   } @if (!editMode) {
 

--- a/projects/social_platform/src/app/ui/widgets/news-card/news-card.component.ts
+++ b/projects/social_platform/src/app/ui/widgets/news-card/news-card.component.ts
@@ -28,7 +28,6 @@ import {
 } from "@corelib";
 import { FileService } from "@core/lib/services/file/file.service";
 import { nanoid } from "nanoid";
-import { expandElement } from "@utils/expand-element";
 import { ClickOutsideModule } from "ng-click-outside";
 import { CarouselComponent } from "./carousel/carousel.component";
 import { ImgCardComponent } from "@ui/primitives/img-card/img-card.component";
@@ -40,6 +39,7 @@ import { FileItemComponent } from "@ui/primitives/file-item/file-item.component"
 import { FileModel } from "@domain/file/file.model";
 import { catchError, forkJoin, noop, Observable, of, take, tap } from "rxjs";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
+import { ExpandService } from "@api/expand/expand.service";
 
 /** Виджет карточки новости: отображение, лайк, режим редактирования. */
 @Component({
@@ -65,9 +65,11 @@ import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
     ImgCardComponent,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
+  providers: [ExpandService],
 })
 export class NewsCardComponent implements OnInit {
   private readonly destroyRef = inject(DestroyRef);
+  private readonly expandService = inject(ExpandService);
 
   constructor(
     private readonly snackbarService: SnackbarService,
@@ -94,8 +96,6 @@ export class NewsCardComponent implements OnInit {
 
   placeholderUrl = "https://hwchamber.co.uk/wp-content/uploads/2022/04/avatar-placeholder.gif";
 
-  newsTextExpandable!: boolean;
-  readMore = false;
   editMode = false;
   editForm: FormGroup;
 
@@ -195,9 +195,9 @@ export class NewsCardComponent implements OnInit {
   }
 
   ngAfterViewInit(): void {
-    const newsTextElem = this.newsTextEl?.nativeElement;
-    this.newsTextExpandable = newsTextElem?.clientHeight < newsTextElem?.scrollHeight;
-    this.cdRef.detectChanges();
+    setTimeout(() => {
+      this.expandService.checkExpandable("description", true, this.newsTextEl);
+    });
   }
 
   onCopyLink(): void {
@@ -423,8 +423,15 @@ export class NewsCardComponent implements OnInit {
     this.loggerService.info("Лайк на изображении с индексом: ", index);
   }
 
-  onExpandNewsText(elem: HTMLElement, expandedClass: string, isExpanded: boolean): void {
-    expandElement(elem, expandedClass, isExpanded);
-    this.readMore = !isExpanded;
+  protected readonly descriptionExpandable = this.expandService.descriptionExpandable;
+  protected readonly readFullDescription = this.expandService.readFullDescription;
+
+  protected onExpandNewsText(elem: HTMLElement): void {
+    this.expandService.onExpand(
+      "description",
+      elem,
+      "expanded",
+      this.expandService.readFullDescription()
+    );
   }
 }

--- a/projects/social_platform/src/app/ui/widgets/project-vacancy-card/project-vacancy-card.component.html
+++ b/projects/social_platform/src/app/ui/widgets/project-vacancy-card/project-vacancy-card.component.html
@@ -56,12 +56,9 @@
     @if (vacancy.description) {
     <div class="text-body-10 about__text">
       <p #descEl [innerHTML]="vacancy.description | parseLinks | parseBreaks"></p>
-      @if (descriptionExpandable) {
-      <div
-        class="read-more text-body-10"
-        (click)="onExpandDescription(descEl, 'expanded', readFullDescription)"
-      >
-        {{ readFullDescription ? "cкрыть" : "подробнее" }}
+      @if (descriptionExpandable()) {
+      <div class="read-more text-body-10" (click)="onExpandDescription(descEl)">
+        {{ readFullDescription() ? "cкрыть" : "подробнее" }}
       </div>
       }
     </div>

--- a/projects/social_platform/src/app/ui/widgets/project-vacancy-card/project-vacancy-card.component.ts
+++ b/projects/social_platform/src/app/ui/widgets/project-vacancy-card/project-vacancy-card.component.ts
@@ -3,7 +3,6 @@ import { CommonModule } from "@angular/common";
 import {
   AfterViewInit,
   ChangeDetectionStrategy,
-  ChangeDetectorRef,
   Component,
   ElementRef,
   inject,
@@ -16,10 +15,10 @@ import { Vacancy } from "@domain/vacancy/vacancy.model";
 import { IconComponent } from "@uilib";
 import { ButtonComponent } from "@ui/primitives";
 import { DayjsPipe, ParseBreaksPipe, ParseLinksPipe, TruncatePipe } from "@corelib";
-import { expandElement } from "@utils/expand-element";
 import { TagComponent } from "@ui/primitives/tag/tag.component";
 import { AvatarComponent } from "@ui/primitives/avatar/avatar.component";
 import { AppRoutes } from "@api/paths/app-routes";
+import { ExpandService } from "@api/expand/expand.service";
 
 /** Компонент карточки вакансии проекта с возможностью раскрытия описания. */
 @Component({
@@ -40,33 +39,38 @@ import { AppRoutes } from "@api/paths/app-routes";
   templateUrl: "./project-vacancy-card.component.html",
   styleUrl: "./project-vacancy-card.component.scss",
   changeDetection: ChangeDetectionStrategy.OnPush,
+  providers: [ExpandService],
 })
 export class ProjectVacancyCardComponent implements OnInit, AfterViewInit {
+  private readonly expandService = inject(ExpandService);
+
   protected readonly AppRoutes = AppRoutes;
   @Input({ required: true }) vacancy!: Vacancy;
   @Input() type: "vacancies" | "project" = "project";
 
-  @ViewChild("descEl") descEl?: ElementRef;
+  @ViewChild("descEl") private descEl?: ElementRef;
 
-  private readonly cdRef = inject(ChangeDetectorRef);
+  endSliceOfSkills = 0;
+
+  protected readonly descriptionExpandable = this.expandService.descriptionExpandable;
+  protected readonly readFullDescription = this.expandService.readFullDescription;
 
   ngOnInit(): void {
     this.endSliceOfSkills = this.type === "project" ? 5 : 3;
   }
 
   ngAfterViewInit(): void {
-    const descElement = this.descEl?.nativeElement;
-    this.descriptionExpandable = descElement?.clientHeight < descElement?.scrollHeight;
-
-    this.cdRef.detectChanges();
+    setTimeout(() => {
+      this.expandService.checkExpandable("description", true, this.descEl);
+    });
   }
 
-  descriptionExpandable!: boolean;
-  readFullDescription = false;
-  endSliceOfSkills = 0;
-
-  onExpandDescription(elem: HTMLElement, expandedClass: string, isExpanded: boolean): void {
-    expandElement(elem, expandedClass, isExpanded);
-    this.readFullDescription = !isExpanded;
+  protected onExpandDescription(elem: HTMLElement): void {
+    this.expandService.onExpand(
+      "description",
+      elem,
+      "expanded",
+      this.expandService.readFullDescription()
+    );
   }
 }


### PR DESCRIPTION
- Create RatingCardService with computed signals and rating flow methods
- Move service to services/ folder within rating-card
- Replace all getter proxies with protected readonly field aliases
- Remove unused fields (_currentIndex, _projects)
- Consolidate ExpandService usage across 5 components
- Remove dead expand code from CourseInfoComponent
- All injects changed to private readonly
- Templates no longer access services directly