### PR TITLE
Fix onboarding profile update

### DIFF
--- a/projects/social_platform/src/app/api/auth/use-cases/update-profile.use-case.spec.ts
+++ b/projects/social_platform/src/app/api/auth/use-cases/update-profile.use-case.spec.ts
@@ -1,0 +1,57 @@
+/** @format */
+
+import { TestBed } from "@angular/core/testing";
+import { of, throwError } from "rxjs";
+import { AuthRepositoryPort } from "@domain/auth/ports/auth.repository.port";
+import { User, UserInput } from "@domain/auth/user.model";
+import { UpdateProfileUseCase } from "./update-profile.use-case";
+
+describe("UpdateProfileUseCase", () => {
+  let useCase: UpdateProfileUseCase;
+  let repository: { updateProfile: ReturnType<typeof vi.fn> };
+
+  const data: UserInput = { city: "Москва" };
+  const updatedProfile = { id: 42 } as User;
+
+  beforeEach(() => {
+    repository = { updateProfile: vi.fn() };
+    TestBed.configureTestingModule({
+      providers: [UpdateProfileUseCase, { provide: AuthRepositoryPort, useValue: repository }],
+    });
+    useCase = TestBed.inject(UpdateProfileUseCase);
+  });
+
+  it("передает profileId и данные в repository", () => {
+    repository.updateProfile.mockReturnValue(of(updatedProfile));
+
+    useCase.execute(42, data).subscribe();
+
+    expect(repository.updateProfile).toHaveBeenCalledExactlyOnceWith(42, data);
+  });
+
+  it("сохраняет успешный Result-контракт", () =>
+    new Promise<void>(done => {
+      repository.updateProfile.mockReturnValue(of(updatedProfile));
+
+      useCase.execute(42, data).subscribe(result => {
+        expect(result.ok).toBe(true);
+        if (result.ok) expect(result.value).toBe(updatedProfile);
+        done();
+      });
+    }));
+
+  it("преобразует ошибку repository в server_error", () =>
+    new Promise<void>(done => {
+      const cause = new Error("server failed");
+      repository.updateProfile.mockReturnValue(throwError(() => cause));
+
+      useCase.execute(42, data).subscribe(result => {
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+          expect(result.error.kind).toBe("server_error");
+          expect(result.error.cause).toBe(cause);
+        }
+        done();
+      });
+    }));
+});

--- a/projects/social_platform/src/app/api/auth/use-cases/update-profile.use-case.ts
+++ b/projects/social_platform/src/app/api/auth/use-cases/update-profile.use-case.ts
@@ -11,8 +11,11 @@ import { catchError, map, Observable, of } from "rxjs";
 export class UpdateProfileUseCase {
   private readonly authRepository = inject(AuthRepositoryPort);
 
-  execute(data: UserInput): Observable<Result<User, { kind: "server_error"; cause?: unknown }>> {
-    return this.authRepository.updateProfile(data).pipe(
+  execute(
+    profileId: number,
+    data: UserInput,
+  ): Observable<Result<User, { kind: "server_error"; cause?: unknown }>> {
+    return this.authRepository.updateProfile(profileId, data).pipe(
       map(profile => ok<User>(profile)),
       catchError(error => of(fail({ kind: "server_error", cause: error } as const))),
     );

--- a/projects/social_platform/src/app/api/onboarding/facades/stages/onboarding-stage-one-info.service.ts
+++ b/projects/social_platform/src/app/api/onboarding/facades/stages/onboarding-stage-one-info.service.ts
@@ -16,6 +16,7 @@ import { failure, initial, loading } from "@domain/shared/async-state";
 import { AppRoutes } from "@api/paths/app-routes";
 import { ProfileInfoService } from "@api/profile/facades/profile-info.service";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
+import { isValidProfileId } from "@domain/auth/profile-id";
 
 /** Координирует шаг выбора специализаций и сохранение первого этапа. */
 @Injectable()
@@ -80,13 +81,19 @@ export class OnboardingStageOneInfoService {
       return;
     }
 
+    const profile = this.profile();
+    if (!isValidProfileId(profile?.id)) {
+      this.stageSubmitting.set(failure("submit_error"));
+      return;
+    }
+
     this.stageSubmitting.set(loading());
 
     this.updateProfileUseCase
-      .execute(this.stageForm.value)
+      .execute(profile.id, this.stageForm.value)
       .pipe(
         concatMap(result =>
-          result.ok ? this.updateOnboardingStageUseCase.execute(2, this.profile()!.id) : of(result),
+          result.ok ? this.updateOnboardingStageUseCase.execute(2, profile.id) : of(result),
         ),
         takeUntilDestroyed(this.destroyRef),
       )

--- a/projects/social_platform/src/app/api/onboarding/facades/stages/onboarding-stage-three-info.service.ts
+++ b/projects/social_platform/src/app/api/onboarding/facades/stages/onboarding-stage-three-info.service.ts
@@ -9,10 +9,11 @@ import { OnboardingStageThreeUIInfoService } from "./ui/onboarding-stage-three-u
 import { LoggerService } from "@core/lib/services/logger/logger.service";
 import { UpdateProfileUseCase } from "@api/auth/use-cases/update-profile.use-case";
 import { UpdateOnboardingStageUseCase } from "@api/auth/use-cases/update-onboarding-stage.use-case";
-import { loading } from "@domain/shared/async-state";
+import { failure, loading } from "@domain/shared/async-state";
 import { AppRoutes } from "@api/paths/app-routes";
 import { ProfileInfoService } from "@api/profile/facades/profile-info.service";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
+import { isValidProfileId } from "@domain/auth/profile-id";
 
 /** Фасад этапа 3 онбординга: обновление профиля и продвижение этапа онбординга. */
 @Injectable()
@@ -49,15 +50,19 @@ export class OnboardingStageThreeInfoService {
       return;
     }
 
+    const profile = this.profile();
+    if (!isValidProfileId(profile?.id)) {
+      this.stageSubmitting.set(failure("submit_error"));
+      return;
+    }
+
     this.stageSubmitting.set(loading());
 
     this.updateProfileUseCase
-      .execute({ userType: this.userRole() })
+      .execute(profile.id, { userType: this.userRole() })
       .pipe(
         concatMap(result =>
-          result.ok
-            ? this.updateOnboardingStageUseCase.execute(null, this.profile()!.id)
-            : of(result),
+          result.ok ? this.updateOnboardingStageUseCase.execute(null, profile.id) : of(result),
         ),
         tap(result => {
           if (!result.ok) return;

--- a/projects/social_platform/src/app/api/onboarding/facades/stages/onboarding-stage-two-info.service.ts
+++ b/projects/social_platform/src/app/api/onboarding/facades/stages/onboarding-stage-two-info.service.ts
@@ -15,6 +15,7 @@ import { AppRoutes } from "@api/paths/app-routes";
 import { SearchesService } from "@api/searches/searches.service";
 import { ProfileInfoService } from "@api/profile/facades/profile-info.service";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
+import { INVALID_PROFILE_ID_MESSAGE, isValidProfileId } from "@domain/auth/profile-id";
 
 /** Координирует шаг выбора навыков и сохранение второго этапа. */
 @Injectable()
@@ -69,15 +70,24 @@ export class OnboardingStageTwoInfoService {
       return;
     }
 
+    const profile = this.profile();
+    if (!isValidProfileId(profile?.id)) {
+      this.stageSubmitting.set(failure("submit_error"));
+      this.onboardingStageTwoUIInfoService.applySubmitErrorModal(
+        new Error(INVALID_PROFILE_ID_MESSAGE),
+      );
+      return;
+    }
+
     this.stageSubmitting.set(loading());
 
     const { skills } = this.stageForm.getRawValue();
 
     this.updateProfileUseCase
-      .execute({ skillsIds: skills.map((skill: Skill) => skill.id) })
+      .execute(profile.id, { skillsIds: skills.map((skill: Skill) => skill.id) })
       .pipe(
         concatMap(result =>
-          result.ok ? this.updateOnboardingStageUseCase.execute(2, this.profile()!.id) : of(result),
+          result.ok ? this.updateOnboardingStageUseCase.execute(2, profile.id) : of(result),
         ),
         takeUntilDestroyed(this.destroyRef),
       )

--- a/projects/social_platform/src/app/api/onboarding/facades/stages/onboarding-stage-zero-info.service.spec.ts
+++ b/projects/social_platform/src/app/api/onboarding/facades/stages/onboarding-stage-zero-info.service.spec.ts
@@ -1,0 +1,181 @@
+/** @format */
+
+import { signal, WritableSignal } from "@angular/core";
+import { TestBed } from "@angular/core/testing";
+import { FormArray, FormBuilder, FormGroup } from "@angular/forms";
+import { Router } from "@angular/router";
+import { ValidationService } from "@corelib";
+import { of } from "rxjs";
+import { UpdateProfileUseCase } from "@api/auth/use-cases/update-profile.use-case";
+import { UpdateOnboardingStageUseCase } from "@api/auth/use-cases/update-onboarding-stage.use-case";
+import { ProfileInfoService } from "@api/profile/facades/profile-info.service";
+import { User } from "@domain/auth/user.model";
+import { initial } from "@domain/shared/async-state";
+import { fail, ok } from "@domain/shared/result.type";
+import { OnboardingService } from "../../onboarding.service";
+import { OnboardingStageZeroInfoService } from "./onboarding-stage-zero-info.service";
+import { OnboardingStageZeroUIInfoService } from "./ui/onboarding-stage-zero-ui-info.service";
+import { OnboardingUIInfoService } from "./ui/onboarding-ui-info.service";
+
+describe("OnboardingStageZeroInfoService", () => {
+  let service: OnboardingStageZeroInfoService;
+  let profile: WritableSignal<User | null>;
+  let updateProfileUseCase: { execute: ReturnType<typeof vi.fn> };
+  let updateOnboardingStageUseCase: { execute: ReturnType<typeof vi.fn> };
+  let profileInfoService: {
+    profile: typeof profile;
+    applyProfileUpdated: ReturnType<typeof vi.fn>;
+  };
+  let stageZeroUI: {
+    stageForm: FormGroup;
+    achievements: FormArray;
+    education: FormArray;
+    workExperience: FormArray;
+    userLanguages: FormArray;
+    applySkipRegistrationModalError: ReturnType<typeof vi.fn>;
+    applySubmitModalError: ReturnType<typeof vi.fn>;
+  };
+  let stageSubmitting: WritableSignal<any>;
+  let skipSubmitting: WritableSignal<any>;
+
+  const currentProfile = { id: 42 } as User;
+  const updatedProfile = { id: 42, firstName: "Иван" } as User;
+
+  beforeEach(() => {
+    const formBuilder = new FormBuilder();
+    const stageForm = formBuilder.group({
+      avatar: ["avatar.png"],
+      city: ["Москва"],
+      education: formBuilder.array([]),
+      workExperience: formBuilder.array([]),
+      userLanguages: formBuilder.array([]),
+      achievements: formBuilder.array([]),
+    });
+
+    profile = signal<User | null>(currentProfile);
+    updateProfileUseCase = { execute: vi.fn().mockReturnValue(of(ok(updatedProfile))) };
+    updateOnboardingStageUseCase = {
+      execute: vi.fn().mockReturnValue(of(ok(updatedProfile))),
+    };
+    profileInfoService = {
+      profile,
+      applyProfileUpdated: vi.fn(),
+    };
+    stageZeroUI = {
+      stageForm,
+      achievements: stageForm.get("achievements") as FormArray,
+      education: stageForm.get("education") as FormArray,
+      workExperience: stageForm.get("workExperience") as FormArray,
+      userLanguages: stageForm.get("userLanguages") as FormArray,
+      applySkipRegistrationModalError: vi.fn(),
+      applySubmitModalError: vi.fn(),
+    };
+    stageSubmitting = signal(initial());
+    skipSubmitting = signal(initial());
+
+    TestBed.configureTestingModule({
+      providers: [
+        OnboardingStageZeroInfoService,
+        {
+          provide: Router,
+          useValue: { navigateByUrl: vi.fn().mockResolvedValue(true) },
+        },
+        {
+          provide: ValidationService,
+          useValue: { getFormValidation: vi.fn().mockReturnValue(true) },
+        },
+        {
+          provide: OnboardingService,
+          useValue: { setFormValue: vi.fn() },
+        },
+        {
+          provide: OnboardingUIInfoService,
+          useValue: {
+            stageSubmitting$: stageSubmitting,
+            skipSubmitting$: skipSubmitting,
+          },
+        },
+        {
+          provide: OnboardingStageZeroUIInfoService,
+          useValue: stageZeroUI,
+        },
+        {
+          provide: ProfileInfoService,
+          useValue: profileInfoService,
+        },
+        {
+          provide: UpdateProfileUseCase,
+          useValue: updateProfileUseCase,
+        },
+        {
+          provide: UpdateOnboardingStageUseCase,
+          useValue: updateOnboardingStageUseCase,
+        },
+      ],
+    });
+
+    service = TestBed.inject(OnboardingStageZeroInfoService);
+  });
+
+  it("onSubmit передает profile.id отдельно от данных формы", () => {
+    service.onSubmit();
+
+    expect(updateProfileUseCase.execute).toHaveBeenCalledExactlyOnceWith(42, {
+      avatar: "avatar.png",
+      city: "Москва",
+      education: [],
+      workExperience: [],
+      userLanguages: [],
+      achievements: [],
+    });
+  });
+
+  it("onSkipRegistration передает profile.id отдельно от кратких данных", () => {
+    service.onSkipRegistration();
+
+    expect(updateProfileUseCase.execute).toHaveBeenCalledExactlyOnceWith(42, {
+      avatar: "avatar.png",
+      city: "Москва",
+    });
+    expect(profileInfoService.applyProfileUpdated).toHaveBeenCalledExactlyOnceWith(updatedProfile);
+  });
+
+  it("не обновляет профиль и переводит submit в failure без загруженного profile", () => {
+    profile.set(null);
+
+    service.onSubmit();
+
+    expect(updateProfileUseCase.execute).not.toHaveBeenCalled();
+    expect(updateOnboardingStageUseCase.execute).not.toHaveBeenCalled();
+    expect(stageSubmitting().status).toBe("failure");
+    expect(stageZeroUI.applySubmitModalError).toHaveBeenCalledOnce();
+  });
+
+  it("не обновляет профиль и переводит skip в failure без корректного profile.id", () => {
+    profile.set({ id: undefined } as unknown as User);
+
+    service.onSkipRegistration();
+
+    expect(updateProfileUseCase.execute).not.toHaveBeenCalled();
+    expect(updateOnboardingStageUseCase.execute).not.toHaveBeenCalled();
+    expect(skipSubmitting().status).toBe("failure");
+    expect(stageZeroUI.applySkipRegistrationModalError).toHaveBeenCalledOnce();
+  });
+
+  it("не обновляет onboarding stage после неуспешного PATCH профиля", () => {
+    updateProfileUseCase.execute.mockReturnValue(
+      of(fail({ kind: "server_error", cause: new Error("PATCH failed") })),
+    );
+
+    service.onSubmit();
+
+    expect(updateOnboardingStageUseCase.execute).not.toHaveBeenCalled();
+  });
+
+  it("после успешного PATCH обновляет onboarding stage с корректным ID", () => {
+    service.onSubmit();
+
+    expect(updateOnboardingStageUseCase.execute).toHaveBeenCalledExactlyOnceWith(1, 42);
+    expect(profileInfoService.applyProfileUpdated).toHaveBeenCalledExactlyOnceWith(updatedProfile);
+  });
+});

--- a/projects/social_platform/src/app/api/onboarding/facades/stages/onboarding-stage-zero-info.service.ts
+++ b/projects/social_platform/src/app/api/onboarding/facades/stages/onboarding-stage-zero-info.service.ts
@@ -14,6 +14,7 @@ import { UpdateProfileUseCase } from "@api/auth/use-cases/update-profile.use-cas
 import { UpdateOnboardingStageUseCase } from "@api/auth/use-cases/update-onboarding-stage.use-case";
 import { ProfileInfoService } from "@api/profile/facades/profile-info.service";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
+import { INVALID_PROFILE_ID_MESSAGE, isValidProfileId } from "@domain/auth/profile-id";
 
 /** Координирует первый шаг онбординга: профильные поля, FormArray, сохранение этапа. */
 @Injectable()
@@ -68,6 +69,15 @@ export class OnboardingStageZeroInfoService {
       return;
     }
 
+    const profile = this.profile();
+    if (!isValidProfileId(profile?.id)) {
+      this.skipSubmitting.set(failure("skip_error"));
+      this.onboardingStageZeroUIInfoService.applySkipRegistrationModalError(
+        new Error(INVALID_PROFILE_ID_MESSAGE),
+      );
+      return;
+    }
+
     const onboardingSkipInfo = {
       avatar: this.stageForm.get("avatar")?.value,
       city: this.stageForm.get("city")?.value,
@@ -76,7 +86,7 @@ export class OnboardingStageZeroInfoService {
     this.skipSubmitting.set(loading());
 
     this.updateProfileUseCase
-      .execute(onboardingSkipInfo as Partial<User>)
+      .execute(profile.id, onboardingSkipInfo as Partial<User>)
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: result => {
@@ -88,6 +98,7 @@ export class OnboardingStageZeroInfoService {
             return;
           }
 
+          this.profileInfoService.applyProfileUpdated(result.value);
           this.completeRegistration(3);
         },
       });
@@ -96,6 +107,15 @@ export class OnboardingStageZeroInfoService {
   onSubmit(): void {
     if (!this.validationService.getFormValidation(this.stageForm)) {
       this.achievements.markAllAsTouched();
+      return;
+    }
+
+    const profile = this.profile();
+    if (!isValidProfileId(profile?.id)) {
+      this.stageSubmitting.set(failure("submit_error"));
+      this.onboardingStageZeroUIInfoService.applySubmitModalError(
+        new Error(INVALID_PROFILE_ID_MESSAGE),
+      );
       return;
     }
 
@@ -111,10 +131,10 @@ export class OnboardingStageZeroInfoService {
     this.stageSubmitting.set(loading());
 
     this.updateProfileUseCase
-      .execute(newStageForm as Partial<User>)
+      .execute(profile.id, newStageForm as Partial<User>)
       .pipe(
         concatMap(result =>
-          result.ok ? this.updateOnboardingStageUseCase.execute(1, this.profile()!.id) : of(result),
+          result.ok ? this.updateOnboardingStageUseCase.execute(1, profile.id) : of(result),
         ),
         takeUntilDestroyed(this.destroyRef),
       )

--- a/projects/social_platform/src/app/api/profile/facades/edit/profile-edit-info.service.ts
+++ b/projects/social_platform/src/app/api/profile/facades/edit/profile-edit-info.service.ts
@@ -14,6 +14,7 @@ import { SaveProfileUseCase } from "@api/profile/use-cases/save-profile.use-case
 import { ProfileInfoService } from "../profile-info.service";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { SnackbarService } from "@domain/shared/snackbar.service";
+import { INVALID_PROFILE_ID_MESSAGE, isValidProfileId } from "@domain/auth/profile-id";
 
 /** Фасад редактирования профиля: сбор формы, `SaveProfileUseCase`, раскрытие групп. */
 @Injectable()
@@ -138,6 +139,14 @@ export class ProfileEditInfoService {
       return;
     }
 
+    const profileId = this.profileId();
+    if (!isValidProfileId(profileId)) {
+      this.profileFormSubmitting$.set(failure("profile_edit_error"));
+      this.isModalErrorSkillsChoose.set(true);
+      this.isModalErrorSkillChooseText.set(INVALID_PROFILE_ID_MESSAGE);
+      return;
+    }
+
     this.profileFormSubmitting$.set(loading());
 
     const achievements = this.achievements.value.map((achievement: Achievement) => ({
@@ -157,7 +166,6 @@ export class ProfileEditInfoService {
 
     // Построение объекта профиля с только необходимыми полями
     const newProfile: any = {
-      id: this.profileId(),
       first_name: this.profileForm.value.firstName,
       last_name: this.profileForm.value.lastName,
       email: this.profileForm.value.email,
@@ -198,7 +206,7 @@ export class ProfileEditInfoService {
     }
 
     this.saveProfileUseCase
-      .execute(newProfile)
+      .execute(profileId, newProfile)
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(result => {
         if (!result.ok) {

--- a/projects/social_platform/src/app/api/profile/facades/edit/profile-form.service.ts
+++ b/projects/social_platform/src/app/api/profile/facades/edit/profile-form.service.ts
@@ -2,7 +2,7 @@
 
 import { DestroyRef, inject, Injectable, Injector, signal } from "@angular/core";
 import { FormArray, FormBuilder, FormControl, FormGroup, Validators } from "@angular/forms";
-import { concatMap, filter, map, Observable, skip, take } from "rxjs";
+import { concatMap, filter, map, Observable, skip, take, throwError } from "rxjs";
 import { yearRangeValidators } from "@utils/yearRangeValidators";
 import { User, UserRolesData } from "@domain/auth/user.model";
 import { Specialization } from "@domain/specializations/specialization.model";
@@ -15,6 +15,7 @@ import { languageLevelsList, languageNamesList } from "@core/consts/lists/langua
 import { AuthRepositoryPort } from "@domain/auth/ports/auth.repository.port";
 import { ProfileInfoService } from "../profile-info.service";
 import { takeUntilDestroyed, toObservable } from "@angular/core/rxjs-interop";
+import { INVALID_PROFILE_ID_MESSAGE, isValidProfileId } from "@domain/auth/profile-id";
 
 /** Реактивная форма профиля: построение `FormGroup`, справочники (роли, годы, образование), inline-специализации. */
 @Injectable({ providedIn: "root" })
@@ -364,8 +365,13 @@ export class ProfileFormService {
   }
 
   changeUserType(typeId: number): Observable<void> {
+    const profileId = this.profileId();
+    if (!isValidProfileId(profileId)) {
+      return throwError(() => new Error(INVALID_PROFILE_ID_MESSAGE));
+    }
+
     return this.authRepository
-      .updateProfile({
+      .updateProfile(profileId, {
         email: this.profileForm.value.email,
         firstName: this.profileForm.value.firstName,
         lastName: this.profileForm.value.lastName,

--- a/projects/social_platform/src/app/api/profile/use-cases/save-profile.use-case.spec.ts
+++ b/projects/social_platform/src/app/api/profile/use-cases/save-profile.use-case.spec.ts
@@ -25,9 +25,9 @@ describe("SaveProfileUseCase", () => {
     setup();
     repo.updateProfile.mockReturnValue(of(freshUser));
 
-    useCase.execute(command).subscribe();
+    useCase.execute(42, command).subscribe();
 
-    expect(repo.updateProfile).toHaveBeenCalledExactlyOnceWith(command);
+    expect(repo.updateProfile).toHaveBeenCalledExactlyOnceWith(42, command);
   });
 
   it("при успехе возвращает ok со профилем из updateProfile", () =>
@@ -35,7 +35,7 @@ describe("SaveProfileUseCase", () => {
       setup();
       repo.updateProfile.mockReturnValue(of(freshUser));
 
-      useCase.execute(command).subscribe(result => {
+      useCase.execute(42, command).subscribe(result => {
         expect(result.ok).toBe(true);
         if (result.ok) expect(result.value).toBe(freshUser);
         done();
@@ -48,7 +48,7 @@ describe("SaveProfileUseCase", () => {
       const boom = { error: { phone_number: ["плохой номер"] } };
       repo.updateProfile.mockReturnValue(throwError(() => boom));
 
-      useCase.execute(command).subscribe(result => {
+      useCase.execute(42, command).subscribe(result => {
         expect(result.ok).toBe(false);
         if (!result.ok) {
           expect(result.error.kind).toBe("profile_edit_error");

--- a/projects/social_platform/src/app/api/profile/use-cases/save-profile.use-case.ts
+++ b/projects/social_platform/src/app/api/profile/use-cases/save-profile.use-case.ts
@@ -14,8 +14,8 @@ export type SaveProfileResultError = { kind: "profile_edit_error"; cause?: SaveP
 export class SaveProfileUseCase {
   private readonly authRepository = inject(AuthRepositoryPort);
 
-  execute(command: UserInput): Observable<Result<User, SaveProfileResultError>> {
-    return this.authRepository.updateProfile(command).pipe(
+  execute(profileId: number, command: UserInput): Observable<Result<User, SaveProfileResultError>> {
+    return this.authRepository.updateProfile(profileId, command).pipe(
       map(profile => ok<User>(profile)),
       catchError(error =>
         of(fail<SaveProfileResultError>({ kind: "profile_edit_error", cause: error })),

--- a/projects/social_platform/src/app/domain/auth/ports/auth.repository.port.ts
+++ b/projects/social_platform/src/app/domain/auth/ports/auth.repository.port.ts
@@ -19,7 +19,7 @@ export abstract class AuthRepositoryPort {
   abstract resendEmail(email: string): Observable<User>;
   abstract fetchUser(id: number): Observable<User>;
   abstract fetchProfile(): Observable<User>;
-  abstract updateProfile(data: UserInput): Observable<User>;
+  abstract updateProfile(profileId: number, data: UserInput): Observable<User>;
   abstract updateOnboardingStage(stage: number | null, userId: number): Observable<User>;
   abstract updateAvatar(url: string, userId: number): Observable<User>;
   abstract fetchLeaderProjects(): Observable<ApiPagination<Project>>;

--- a/projects/social_platform/src/app/domain/auth/profile-id.ts
+++ b/projects/social_platform/src/app/domain/auth/profile-id.ts
@@ -1,0 +1,15 @@
+/**
+ * Сообщение для контролируемой ошибки при попытке обновить профиль без ID.
+ *
+ * @format
+ */
+
+export const INVALID_PROFILE_ID_MESSAGE =
+  "Не указан корректный идентификатор пользователя для обновления профиля";
+
+/**
+ * Проверяет, что идентификатор можно безопасно использовать в URL профиля.
+ */
+export function isValidProfileId(profileId: unknown): profileId is number {
+  return typeof profileId === "number" && Number.isInteger(profileId) && profileId > 0;
+}

--- a/projects/social_platform/src/app/infrastructure/adapters/auth/auth-http.adapter.spec.ts
+++ b/projects/social_platform/src/app/infrastructure/adapters/auth/auth-http.adapter.spec.ts
@@ -4,8 +4,9 @@ import { TestBed } from "@angular/core/testing";
 import { of } from "rxjs";
 import { ApiService, TokenService } from "@corelib";
 import { AuthHttpAdapter } from "./auth-http.adapter";
-import { User } from "@domain/auth/user.model";
+import { User, UserRaw } from "@domain/auth/user.model";
 import { LoginResponse, RegisterResponse } from "@core/lib/models/auth/http.model";
+import { INVALID_PROFILE_ID_MESSAGE } from "@domain/auth/profile-id";
 
 describe("AuthHttpAdapter", () => {
   let adapter: AuthHttpAdapter;
@@ -122,15 +123,33 @@ describe("AuthHttpAdapter", () => {
     });
   });
 
-  it("saveProfile идёт в PATCH /auth/users/:id/ с частичными данными", () => {
+  it("saveProfile использует отдельный profileId и передает исходный payload", () => {
     setup();
     api.patch.mockReturnValue(of({} as User));
-    const profile: Partial<User> = { id: 7, firstName: "A" };
+    const profile: Partial<UserRaw> = { id: 7, firstName: "A" };
 
-    adapter.saveProfile(profile).subscribe();
+    adapter.saveProfile(42, profile).subscribe();
 
-    expect(api.patch).toHaveBeenCalledExactlyOnceWith("/auth/users/7/", profile);
+    expect(api.patch).toHaveBeenCalledExactlyOnceWith("/auth/users/42/", profile);
   });
+
+  it.each([undefined, null, Number.NaN, Number.POSITIVE_INFINITY, 0, -1, 1.5])(
+    "saveProfile не вызывает PATCH при некорректном profileId: %s",
+    invalidProfileId => {
+      setup();
+      let receivedError: unknown;
+
+      adapter.saveProfile(invalidProfileId as number, { city: "Москва" }).subscribe({
+        error: error => {
+          receivedError = error;
+        },
+      });
+
+      expect(api.patch).not.toHaveBeenCalled();
+      expect(receivedError).toBeInstanceOf(Error);
+      expect((receivedError as Error).message).toBe(INVALID_PROFILE_ID_MESSAGE);
+    },
+  );
 
   it("setOnboardingStage идёт в PUT /auth/users/:pid/set_onboarding_stage/", () => {
     setup();

--- a/projects/social_platform/src/app/infrastructure/adapters/auth/auth-http.adapter.ts
+++ b/projects/social_platform/src/app/infrastructure/adapters/auth/auth-http.adapter.ts
@@ -2,9 +2,10 @@
 
 import { inject, Injectable } from "@angular/core";
 import { ApiService, TokenService } from "@corelib";
-import { Observable } from "rxjs";
+import { Observable, throwError } from "rxjs";
 import { LoginResponse, RegisterResponse } from "@core/lib/models/auth/http.model";
 import { User, UserRaw } from "@domain/auth/user.model";
+import { INVALID_PROFILE_ID_MESSAGE, isValidProfileId } from "@domain/auth/profile-id";
 import { ProjectDto } from "../project/dto/project.dto";
 import { LoginCommand } from "@domain/auth/commands/login.command";
 import { RegisterCommand } from "@domain/auth/commands/register.command";
@@ -63,8 +64,13 @@ export class AuthHttpAdapter {
     return this.apiService.patch<User>(`${this.AUTH_USERS_URL}/${profileId}/`, { avatar: url });
   }
 
-  saveProfile(newProfile: Partial<UserRaw>): Observable<User> {
-    return this.apiService.patch<User>(`${this.AUTH_USERS_URL}/${newProfile.id}/`, newProfile);
+  /** Обновляет профиль по отдельно проверенному идентификатору маршрута. */
+  saveProfile(profileId: number, newProfile: Partial<UserRaw>): Observable<User> {
+    if (!isValidProfileId(profileId)) {
+      return throwError(() => new Error(INVALID_PROFILE_ID_MESSAGE));
+    }
+
+    return this.apiService.patch<User>(`${this.AUTH_USERS_URL}/${profileId}/`, newProfile);
   }
 
   setOnboardingStage(stage: number | null, profileId: number): Observable<User> {

--- a/projects/social_platform/src/app/infrastructure/repository/auth/auth.repository.spec.ts
+++ b/projects/social_platform/src/app/infrastructure/repository/auth/auth.repository.spec.ts
@@ -5,7 +5,7 @@ import { of } from "rxjs";
 import { AuthRepository } from "./auth.repository";
 import { AuthHttpAdapter } from "../../adapters/auth/auth-http.adapter";
 import { TokenService } from "@corelib";
-import { User } from "@domain/auth/user.model";
+import { User, UserInput } from "@domain/auth/user.model";
 import { LoginResponse, RegisterResponse } from "@core/lib/models/auth/http.model";
 import { ApiPagination } from "@domain/other/api-pagination.model";
 import { ProjectDto } from "../../adapters/project/dto/project.dto";
@@ -116,15 +116,19 @@ describe("AuthRepository", () => {
       });
     }));
 
-  it("updateProfile делегирует в adapter.saveProfile", () =>
+  it("updateProfile передает profileId отдельно и преобразует данные в обе стороны", () =>
     new Promise<void>(done => {
       setup();
-      const data = { id: 1, firstName: "A" } as never;
-      adapter.saveProfile.mockReturnValue(of({ id: 1, firstName: "A" } as User));
+      const data: UserInput = { firstName: "A", personal: { city: "Москва" } };
+      adapter.saveProfile.mockReturnValue(of({ id: 42, firstName: "A", city: "Москва" }));
 
-      repository.updateProfile(data).subscribe(profile => {
-        expect(adapter.saveProfile).toHaveBeenCalledExactlyOnceWith(data);
+      repository.updateProfile(42, data).subscribe(profile => {
+        expect(adapter.saveProfile).toHaveBeenCalledExactlyOnceWith(42, {
+          firstName: "A",
+          city: "Москва",
+        });
         expect(profile).toBeInstanceOf(User);
+        expect(profile.personal.city).toBe("Москва");
         done();
       });
     }));

--- a/projects/social_platform/src/app/infrastructure/repository/auth/auth.repository.ts
+++ b/projects/social_platform/src/app/infrastructure/repository/auth/auth.repository.ts
@@ -60,9 +60,9 @@ export class AuthRepository implements AuthRepositoryPort {
     return this.authAdapter.getProfile().pipe(map(user => userFromRaw(user)));
   }
 
-  updateProfile(data: UserInput): Observable<User> {
+  updateProfile(profileId: number, data: UserInput): Observable<User> {
     const rawData = userToRaw(data);
-    return this.authAdapter.saveProfile(rawData).pipe(map(user => userFromRaw(user)));
+    return this.authAdapter.saveProfile(profileId, rawData).pipe(map(user => userFromRaw(user)));
   }
 
   updateOnboardingStage(stage: number | null, userId: number): Observable<User> {


### PR DESCRIPTION
## Что изменено

- Исправлено формирование `/auth/users/undefined/` при сохранении онбординга.
- ID пользователя передается отдельным обязательным параметром.
- Добавлена проверка корректности ID до HTTP-запроса.
- Обновлены этапы онбординга и сохранение профиля.
- Добавлены тесты для adapter, repository, use cases и stage-zero.

## Проверка

- 837/837 тестов успешно.
- lint успешно, без новых ошибок.
- build успешно.
- git diff --check успешно.
- измененные файлы проходят Prettier.

## Ограничение

Полный `npm run format:check` падает на существующем baseline репозитория и затрагивает файлы вне этого изменения.

## Риски

Backend, React frontend и API-контракты сервера не изменялись.