### PR TITLE
Hotfix/disable mandatory onboarding

### DIFF
--- a/projects/social_platform/src/app/api/auth/use-cases/update-profile.use-case.spec.ts
+++ b/projects/social_platform/src/app/api/auth/use-cases/update-profile.use-case.spec.ts
@@ -1,0 +1,52 @@
+/** @format */
+
+import { TestBed } from "@angular/core/testing";
+import { of, throwError } from "rxjs";
+import { UpdateProfileUseCase } from "./update-profile.use-case";
+import { AuthRepositoryPort } from "@domain/auth/ports/auth.repository.port";
+import { User, UserInput } from "@domain/auth/user.model";
+
+describe("UpdateProfileUseCase", () => {
+  let useCase: UpdateProfileUseCase;
+  let repository: { updateProfile: ReturnType<typeof vi.fn> };
+
+  const data = { city: "Москва" } as UserInput;
+  const updatedProfile = { id: 42 } as User;
+
+  beforeEach(() => {
+    repository = { updateProfile: vi.fn() };
+    TestBed.configureTestingModule({
+      providers: [UpdateProfileUseCase, { provide: AuthRepositoryPort, useValue: repository }],
+    });
+    useCase = TestBed.inject(UpdateProfileUseCase);
+  });
+
+  it("передает profileId и данные в репозиторий отдельными аргументами", () => {
+    repository.updateProfile.mockReturnValue(of(updatedProfile));
+
+    useCase.execute(42, data).subscribe();
+
+    expect(repository.updateProfile).toHaveBeenCalledExactlyOnceWith(42, data);
+  });
+
+  it("сохраняет успешный Result-контракт", () =>
+    new Promise<void>(done => {
+      repository.updateProfile.mockReturnValue(of(updatedProfile));
+
+      useCase.execute(42, data).subscribe(result => {
+        expect(result).toEqual({ ok: true, value: updatedProfile });
+        done();
+      });
+    }));
+
+  it("сохраняет server_error Result-контракт при ошибке", () =>
+    new Promise<void>(done => {
+      const cause = new Error("request failed");
+      repository.updateProfile.mockReturnValue(throwError(() => cause));
+
+      useCase.execute(42, data).subscribe(result => {
+        expect(result).toEqual({ ok: false, error: { kind: "server_error", cause } });
+        done();
+      });
+    }));
+});

--- a/projects/social_platform/src/app/api/auth/use-cases/update-profile.use-case.ts
+++ b/projects/social_platform/src/app/api/auth/use-cases/update-profile.use-case.ts
@@ -11,8 +11,11 @@ import { catchError, map, Observable, of } from "rxjs";
 export class UpdateProfileUseCase {
   private readonly authRepository = inject(AuthRepositoryPort);
 
-  execute(data: UserInput): Observable<Result<User, { kind: "server_error"; cause?: unknown }>> {
-    return this.authRepository.updateProfile(data).pipe(
+  execute(
+    profileId: number,
+    data: UserInput,
+  ): Observable<Result<User, { kind: "server_error"; cause?: unknown }>> {
+    return this.authRepository.updateProfile(profileId, data).pipe(
       map(profile => ok<User>(profile)),
       catchError(error => of(fail({ kind: "server_error", cause: error } as const))),
     );

--- a/projects/social_platform/src/app/api/office/facades/office-info.service.spec.ts
+++ b/projects/social_platform/src/app/api/office/facades/office-info.service.spec.ts
@@ -1,0 +1,124 @@
+/** @format */
+
+import { signal } from "@angular/core";
+import { TestBed } from "@angular/core/testing";
+import { Router } from "@angular/router";
+import { NEVER, of } from "rxjs";
+import { OfficeInfoService } from "./office-info.service";
+import { OfficeUIInfoService } from "./ui/office-ui-info.service";
+import { AuthRepositoryPort } from "@domain/auth/ports/auth.repository.port";
+import { LoggerService } from "@core/lib/services/logger/logger.service";
+import { ChatUnreadStateService } from "@api/chat/chat-unread-state.service";
+import { InviteInfoService } from "@api/invite/facades/invite-info.service";
+import { ProfileInfoService } from "@api/profile/facades/profile-info.service";
+import { IndustryStateInfoService } from "@api/industry/facades/industry-state-info.service";
+import { ConnectChatUseCase } from "@api/chat/use-cases/connect-chat.use-case";
+import { ObserveSetOfflineUseCase } from "@api/chat/use-cases/observe-set-offline.use-case";
+import { ObserveSetOnlineUseCase } from "@api/chat/use-cases/observe-set-online.use-case";
+import { ChatStateService } from "@domain/shared/chat-state.service";
+import { EventBus } from "@domain/shared/event-bus";
+import { ProgramShellInfoService } from "@api/program/facades/program-shell-info.service";
+import { User } from "@domain/auth/user.model";
+
+describe("OfficeInfoService", () => {
+  function setup(onboardingStage: number | null, verificationDate: string | null) {
+    const profile = Object.assign(new User(), {
+      id: 42,
+      personal: { onboardingStage },
+      relations: { verificationDate },
+    });
+    const router = {
+      url: "/office",
+      navigateByUrl: vi.fn(() => Promise.resolve(true)),
+    };
+    const officeUI = {
+      applyCreateNavItems: vi.fn(),
+      applyOpenVerificationModal: vi.fn(),
+      applyVerificationModal: vi.fn(),
+      applyOpenInviteErrorModal: vi.fn(),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        OfficeInfoService,
+        { provide: Router, useValue: router },
+        { provide: LoggerService, useValue: { debug: vi.fn() } },
+        { provide: EventBus, useValue: { emit: vi.fn() } },
+        { provide: AuthRepositoryPort, useValue: { logout: vi.fn(() => of(undefined)) } },
+        {
+          provide: InviteInfoService,
+          useValue: {
+            invites: signal([]),
+            ensureLoaded: vi.fn(),
+            invalidate: vi.fn(),
+          },
+        },
+        { provide: IndustryStateInfoService, useValue: { ensureLoaded: vi.fn() } },
+        { provide: ProgramShellInfoService, useValue: { invalidatePrograms: vi.fn() } },
+        { provide: OfficeUIInfoService, useValue: officeUI },
+        {
+          provide: ProfileInfoService,
+          useValue: {
+            profile: signal<User | null>(profile),
+            ensureProfileLoaded: vi.fn(),
+            invalidateProfile: vi.fn(),
+            invalidateLeaderProjects: vi.fn(),
+          },
+        },
+        {
+          provide: ChatUnreadStateService,
+          useValue: { ensureLoaded: vi.fn(), invalidate: vi.fn() },
+        },
+        { provide: ConnectChatUseCase, useValue: { execute: vi.fn(() => of(undefined)) } },
+        { provide: ObserveSetOfflineUseCase, useValue: { execute: vi.fn(() => NEVER) } },
+        { provide: ObserveSetOnlineUseCase, useValue: { execute: vi.fn(() => NEVER) } },
+        { provide: ChatStateService, useValue: { setOnlineStatus: vi.fn() } },
+      ],
+    });
+
+    const service = TestBed.inject(OfficeInfoService);
+    service.initializationOffice();
+    TestBed.tick();
+
+    return { router, officeUI };
+  }
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("создает навигацию и не открывает onboarding для onboardingStage = 0", () => {
+    const { router, officeUI } = setup(0, "2026-01-01");
+
+    expect(officeUI.applyCreateNavItems).toHaveBeenCalledExactlyOnceWith(42);
+    expect(router.navigateByUrl).not.toHaveBeenCalled();
+  });
+
+  it.each([1, 2])("не открывает onboarding для onboardingStage = %s", onboardingStage => {
+    const { router } = setup(onboardingStage, "2026-01-01");
+
+    expect(router.navigateByUrl).not.toHaveBeenCalled();
+  });
+
+  it("сохраняет обычную навигацию для onboardingStage = null", () => {
+    const { router, officeUI } = setup(null, "2026-01-01");
+
+    expect(officeUI.applyCreateNavItems).toHaveBeenCalledExactlyOnceWith(42);
+    expect(router.navigateByUrl).not.toHaveBeenCalled();
+  });
+
+  it.each([0, 1, 2, null])(
+    "открывает verification modal независимо от onboardingStage = %s",
+    onboardingStage => {
+      const { officeUI } = setup(onboardingStage, null);
+
+      expect(officeUI.applyOpenVerificationModal).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("не открывает verification modal для подтвержденного профиля", () => {
+    const { officeUI } = setup(0, "2026-01-01");
+
+    expect(officeUI.applyOpenVerificationModal).not.toHaveBeenCalled();
+  });
+});

--- a/projects/social_platform/src/app/api/office/facades/office-info.service.ts
+++ b/projects/social_platform/src/app/api/office/facades/office-info.service.ts
@@ -72,11 +72,7 @@ export class OfficeInfoService {
       )
       .subscribe(profile => {
         this.officeUIInfoService.applyCreateNavItems(profile!.id);
-        if (!profile!.doesCompleted()) {
-          this.router
-            .navigateByUrl(AppRoutes.onboarding.root())
-            .then(() => this.logger.debug("Route changed from OfficeComponent"));
-        } else if (
+        if (
           profile!.relations.verificationDate === null &&
           localStorage.getItem("waitVerificationAccepted") !== "true"
         ) {

--- a/projects/social_platform/src/app/api/onboarding/facades/stages/onboarding-stage-one-info.service.ts
+++ b/projects/social_platform/src/app/api/onboarding/facades/stages/onboarding-stage-one-info.service.ts
@@ -16,6 +16,7 @@ import { failure, initial, loading } from "@domain/shared/async-state";
 import { AppRoutes } from "@api/paths/app-routes";
 import { ProfileInfoService } from "@api/profile/facades/profile-info.service";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
+import { isValidProfileId } from "@domain/auth/profile-id";
 
 /** Координирует шаг выбора специализаций и сохранение первого этапа. */
 @Injectable()
@@ -80,13 +81,19 @@ export class OnboardingStageOneInfoService {
       return;
     }
 
+    const profile = this.profile();
+    if (!isValidProfileId(profile?.id)) {
+      this.stageSubmitting.set(failure("submit_error"));
+      return;
+    }
+
     this.stageSubmitting.set(loading());
 
     this.updateProfileUseCase
-      .execute(this.stageForm.value)
+      .execute(profile.id, this.stageForm.value)
       .pipe(
         concatMap(result =>
-          result.ok ? this.updateOnboardingStageUseCase.execute(2, this.profile()!.id) : of(result),
+          result.ok ? this.updateOnboardingStageUseCase.execute(2, profile.id) : of(result),
         ),
         takeUntilDestroyed(this.destroyRef),
       )

--- a/projects/social_platform/src/app/api/onboarding/facades/stages/onboarding-stage-three-info.service.ts
+++ b/projects/social_platform/src/app/api/onboarding/facades/stages/onboarding-stage-three-info.service.ts
@@ -9,10 +9,11 @@ import { OnboardingStageThreeUIInfoService } from "./ui/onboarding-stage-three-u
 import { LoggerService } from "@core/lib/services/logger/logger.service";
 import { UpdateProfileUseCase } from "@api/auth/use-cases/update-profile.use-case";
 import { UpdateOnboardingStageUseCase } from "@api/auth/use-cases/update-onboarding-stage.use-case";
-import { loading } from "@domain/shared/async-state";
+import { failure, loading } from "@domain/shared/async-state";
 import { AppRoutes } from "@api/paths/app-routes";
 import { ProfileInfoService } from "@api/profile/facades/profile-info.service";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
+import { isValidProfileId } from "@domain/auth/profile-id";
 
 /** Фасад этапа 3 онбординга: обновление профиля и продвижение этапа онбординга. */
 @Injectable()
@@ -49,15 +50,19 @@ export class OnboardingStageThreeInfoService {
       return;
     }
 
+    const profile = this.profile();
+    if (!isValidProfileId(profile?.id)) {
+      this.stageSubmitting.set(failure("submit_error"));
+      return;
+    }
+
     this.stageSubmitting.set(loading());
 
     this.updateProfileUseCase
-      .execute({ userType: this.userRole() })
+      .execute(profile.id, { userType: this.userRole() })
       .pipe(
         concatMap(result =>
-          result.ok
-            ? this.updateOnboardingStageUseCase.execute(null, this.profile()!.id)
-            : of(result),
+          result.ok ? this.updateOnboardingStageUseCase.execute(null, profile.id) : of(result),
         ),
         tap(result => {
           if (!result.ok) return;

--- a/projects/social_platform/src/app/api/onboarding/facades/stages/onboarding-stage-two-info.service.ts
+++ b/projects/social_platform/src/app/api/onboarding/facades/stages/onboarding-stage-two-info.service.ts
@@ -15,6 +15,7 @@ import { AppRoutes } from "@api/paths/app-routes";
 import { SearchesService } from "@api/searches/searches.service";
 import { ProfileInfoService } from "@api/profile/facades/profile-info.service";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
+import { INVALID_PROFILE_ID_MESSAGE, isValidProfileId } from "@domain/auth/profile-id";
 
 /** Координирует шаг выбора навыков и сохранение второго этапа. */
 @Injectable()
@@ -69,15 +70,24 @@ export class OnboardingStageTwoInfoService {
       return;
     }
 
+    const profile = this.profile();
+    if (!isValidProfileId(profile?.id)) {
+      this.stageSubmitting.set(failure("submit_error"));
+      this.onboardingStageTwoUIInfoService.applySubmitErrorModal(
+        new Error(INVALID_PROFILE_ID_MESSAGE),
+      );
+      return;
+    }
+
     this.stageSubmitting.set(loading());
 
     const { skills } = this.stageForm.getRawValue();
 
     this.updateProfileUseCase
-      .execute({ skillsIds: skills.map((skill: Skill) => skill.id) })
+      .execute(profile.id, { skillsIds: skills.map((skill: Skill) => skill.id) })
       .pipe(
         concatMap(result =>
-          result.ok ? this.updateOnboardingStageUseCase.execute(2, this.profile()!.id) : of(result),
+          result.ok ? this.updateOnboardingStageUseCase.execute(2, profile.id) : of(result),
         ),
         takeUntilDestroyed(this.destroyRef),
       )

--- a/projects/social_platform/src/app/api/onboarding/facades/stages/onboarding-stage-zero-info.service.spec.ts
+++ b/projects/social_platform/src/app/api/onboarding/facades/stages/onboarding-stage-zero-info.service.spec.ts
@@ -1,0 +1,168 @@
+/** @format */
+
+import { signal } from "@angular/core";
+import { FormArray, FormBuilder } from "@angular/forms";
+import { TestBed } from "@angular/core/testing";
+import { Router } from "@angular/router";
+import { of } from "rxjs";
+import { ValidationService } from "@corelib";
+import { OnboardingStageZeroInfoService } from "./onboarding-stage-zero-info.service";
+import { OnboardingService } from "../../onboarding.service";
+import { OnboardingUIInfoService } from "./ui/onboarding-ui-info.service";
+import { OnboardingStageZeroUIInfoService } from "./ui/onboarding-stage-zero-ui-info.service";
+import { ProfileInfoService } from "@api/profile/facades/profile-info.service";
+import { UpdateProfileUseCase } from "@api/auth/use-cases/update-profile.use-case";
+import { UpdateOnboardingStageUseCase } from "@api/auth/use-cases/update-onboarding-stage.use-case";
+import { User } from "@domain/auth/user.model";
+import { fail, ok } from "@domain/shared/result.type";
+import { initial } from "@domain/shared/async-state";
+
+describe("OnboardingStageZeroInfoService", () => {
+  let service: OnboardingStageZeroInfoService;
+  let profile: ReturnType<typeof signal<User | null>>;
+  let updateProfile: ReturnType<typeof vi.fn>;
+  let updateOnboardingStage: ReturnType<typeof vi.fn>;
+  let applyProfileUpdated: ReturnType<typeof vi.fn>;
+  let stageZeroUI: {
+    stageForm: ReturnType<FormBuilder["group"]>;
+    achievements: FormArray;
+    education: FormArray;
+    workExperience: FormArray;
+    userLanguages: FormArray;
+    applySubmitModalError: ReturnType<typeof vi.fn>;
+    applySkipRegistrationModalError: ReturnType<typeof vi.fn>;
+  };
+  let onboardingUI: {
+    stageSubmitting$: ReturnType<typeof signal>;
+    skipSubmitting$: ReturnType<typeof signal>;
+  };
+
+  beforeEach(() => {
+    const fb = new FormBuilder();
+    const achievements = fb.array([]);
+    const education = fb.array([]);
+    const workExperience = fb.array([]);
+    const userLanguages = fb.array([]);
+    const stageForm = fb.group({
+      avatar: ["avatar.png"],
+      city: ["Москва"],
+      achievements,
+      education,
+      workExperience,
+      userLanguages,
+    });
+
+    profile = signal<User | null>({ id: 42 } as User);
+    updateProfile = vi.fn();
+    updateOnboardingStage = vi.fn();
+    applyProfileUpdated = vi.fn();
+    stageZeroUI = {
+      stageForm,
+      achievements,
+      education,
+      workExperience,
+      userLanguages,
+      applySubmitModalError: vi.fn(),
+      applySkipRegistrationModalError: vi.fn(),
+    };
+    onboardingUI = {
+      stageSubmitting$: signal(initial()),
+      skipSubmitting$: signal(initial()),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        OnboardingStageZeroInfoService,
+        { provide: Router, useValue: { navigateByUrl: vi.fn() } },
+        { provide: ValidationService, useValue: { getFormValidation: vi.fn(() => true) } },
+        {
+          provide: OnboardingService,
+          useValue: { formValue$: of({}), setFormValue: vi.fn() },
+        },
+        { provide: OnboardingUIInfoService, useValue: onboardingUI },
+        { provide: OnboardingStageZeroUIInfoService, useValue: stageZeroUI },
+        {
+          provide: ProfileInfoService,
+          useValue: { profile, applyProfileUpdated },
+        },
+        { provide: UpdateProfileUseCase, useValue: { execute: updateProfile } },
+        {
+          provide: UpdateOnboardingStageUseCase,
+          useValue: { execute: updateOnboardingStage },
+        },
+      ],
+    });
+    service = TestBed.inject(OnboardingStageZeroInfoService);
+  });
+
+  it("onSubmit передает profile.id отдельно от данных формы", () => {
+    updateProfile.mockReturnValue(of(ok({ id: 42 } as User)));
+    updateOnboardingStage.mockReturnValue(of(ok({ id: 42 } as User)));
+
+    service.onSubmit();
+
+    expect(updateProfile).toHaveBeenCalledExactlyOnceWith(42, {
+      avatar: "avatar.png",
+      city: "Москва",
+      education: [],
+      workExperience: [],
+      userLanguages: [],
+      achievements: [],
+    });
+  });
+
+  it("onSkipRegistration использует profile.id и применяет обновленный профиль", () => {
+    const updatedProfile = { id: 42, city: "Москва" } as unknown as User;
+    updateProfile.mockReturnValue(of(ok(updatedProfile)));
+
+    service.onSkipRegistration();
+
+    expect(updateProfile).toHaveBeenCalledExactlyOnceWith(42, {
+      avatar: "avatar.png",
+      city: "Москва",
+    });
+    expect(applyProfileUpdated).toHaveBeenCalledExactlyOnceWith(updatedProfile);
+  });
+
+  it("не обновляет профиль и показывает ошибку, если профиль отсутствует", () => {
+    profile.set(null);
+
+    service.onSubmit();
+
+    expect(updateProfile).not.toHaveBeenCalled();
+    expect(updateOnboardingStage).not.toHaveBeenCalled();
+    expect(onboardingUI.stageSubmitting$().status).toBe("failure");
+    expect(stageZeroUI.applySubmitModalError).toHaveBeenCalledOnce();
+  });
+
+  it("не обновляет профиль и показывает ошибку, если profile.id отсутствует", () => {
+    profile.set({} as User);
+
+    service.onSkipRegistration();
+
+    expect(updateProfile).not.toHaveBeenCalled();
+    expect(updateOnboardingStage).not.toHaveBeenCalled();
+    expect(onboardingUI.skipSubmitting$().status).toBe("failure");
+    expect(stageZeroUI.applySkipRegistrationModalError).toHaveBeenCalledOnce();
+  });
+
+  it("не обновляет onboarding stage после неуспешного обновления профиля", () => {
+    updateProfile.mockReturnValue(of(fail({ kind: "server_error", cause: new Error("fail") })));
+
+    service.onSubmit();
+
+    expect(updateOnboardingStage).not.toHaveBeenCalled();
+    expect(onboardingUI.stageSubmitting$().status).toBe("failure");
+  });
+
+  it("после успешного PATCH обновляет onboarding stage с тем же profile.id", () => {
+    const updatedProfile = { id: 42, onboardingStage: 1 } as User;
+    updateProfile.mockReturnValue(of(ok({ id: 42 } as User)));
+    updateOnboardingStage.mockReturnValue(of(ok(updatedProfile)));
+
+    service.onSubmit();
+
+    expect(updateOnboardingStage).toHaveBeenCalledExactlyOnceWith(1, 42);
+    expect(applyProfileUpdated).toHaveBeenCalledExactlyOnceWith(updatedProfile);
+  });
+});

--- a/projects/social_platform/src/app/api/onboarding/facades/stages/onboarding-stage-zero-info.service.ts
+++ b/projects/social_platform/src/app/api/onboarding/facades/stages/onboarding-stage-zero-info.service.ts
@@ -14,6 +14,7 @@ import { UpdateProfileUseCase } from "@api/auth/use-cases/update-profile.use-cas
 import { UpdateOnboardingStageUseCase } from "@api/auth/use-cases/update-onboarding-stage.use-case";
 import { ProfileInfoService } from "@api/profile/facades/profile-info.service";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
+import { INVALID_PROFILE_ID_MESSAGE, isValidProfileId } from "@domain/auth/profile-id";
 
 /** Координирует первый шаг онбординга: профильные поля, FormArray, сохранение этапа. */
 @Injectable()
@@ -68,6 +69,15 @@ export class OnboardingStageZeroInfoService {
       return;
     }
 
+    const profile = this.profile();
+    if (!isValidProfileId(profile?.id)) {
+      this.skipSubmitting.set(failure("skip_error"));
+      this.onboardingStageZeroUIInfoService.applySkipRegistrationModalError(
+        new Error(INVALID_PROFILE_ID_MESSAGE),
+      );
+      return;
+    }
+
     const onboardingSkipInfo = {
       avatar: this.stageForm.get("avatar")?.value,
       city: this.stageForm.get("city")?.value,
@@ -76,7 +86,7 @@ export class OnboardingStageZeroInfoService {
     this.skipSubmitting.set(loading());
 
     this.updateProfileUseCase
-      .execute(onboardingSkipInfo as Partial<User>)
+      .execute(profile.id, onboardingSkipInfo as Partial<User>)
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: result => {
@@ -88,6 +98,7 @@ export class OnboardingStageZeroInfoService {
             return;
           }
 
+          this.profileInfoService.applyProfileUpdated(result.value);
           this.completeRegistration(3);
         },
       });
@@ -96,6 +107,15 @@ export class OnboardingStageZeroInfoService {
   onSubmit(): void {
     if (!this.validationService.getFormValidation(this.stageForm)) {
       this.achievements.markAllAsTouched();
+      return;
+    }
+
+    const profile = this.profile();
+    if (!isValidProfileId(profile?.id)) {
+      this.stageSubmitting.set(failure("submit_error"));
+      this.onboardingStageZeroUIInfoService.applySubmitModalError(
+        new Error(INVALID_PROFILE_ID_MESSAGE),
+      );
       return;
     }
 
@@ -111,10 +131,10 @@ export class OnboardingStageZeroInfoService {
     this.stageSubmitting.set(loading());
 
     this.updateProfileUseCase
-      .execute(newStageForm as Partial<User>)
+      .execute(profile.id, newStageForm as Partial<User>)
       .pipe(
         concatMap(result =>
-          result.ok ? this.updateOnboardingStageUseCase.execute(1, this.profile()!.id) : of(result),
+          result.ok ? this.updateOnboardingStageUseCase.execute(1, profile.id) : of(result),
         ),
         takeUntilDestroyed(this.destroyRef),
       )

--- a/projects/social_platform/src/app/api/onboarding/facades/stages/ui/onboarding-stage-zero-ui-info.service.ts
+++ b/projects/social_platform/src/app/api/onboarding/facades/stages/ui/onboarding-stage-zero-ui-info.service.ts
@@ -501,13 +501,17 @@ export class OnboardingStageZeroUIInfoService {
   applySubmitModalError(error: any): void {
     this.isModalErrorYear.set(true);
 
-    if (error.error.language) {
+    if (error instanceof Error) {
+      this.isModalErrorYearText.set(error.message);
+    } else if (error.error?.language) {
       this.isModalErrorYearText.set(error.error.language);
     }
   }
 
   applySkipRegistrationModalError(error: any): void {
     this.isModalErrorYear.set(true);
-    this.isModalErrorYearText.set(error.error?.message || "Ошибка сохранения");
+    this.isModalErrorYearText.set(
+      error instanceof Error ? error.message : error.error?.message || "Ошибка сохранения",
+    );
   }
 }

--- a/projects/social_platform/src/app/api/profile/facades/edit/profile-edit-info.service.spec.ts
+++ b/projects/social_platform/src/app/api/profile/facades/edit/profile-edit-info.service.spec.ts
@@ -1,0 +1,108 @@
+/** @format */
+
+import { signal } from "@angular/core";
+import { TestBed } from "@angular/core/testing";
+import { ActivatedRoute } from "@angular/router";
+import { of } from "rxjs";
+import { ProfileEditInfoService } from "./profile-edit-info.service";
+import { ProfileFormService } from "./profile-form.service";
+import { NavigationService } from "../../../paths/navigation.service";
+import { ProjectStepService } from "../../../project/project-step.service";
+import { NavService } from "@api/shared/nav.service";
+import { SaveProfileUseCase } from "@api/profile/use-cases/save-profile.use-case";
+import { ProfileInfoService } from "../profile-info.service";
+import { SnackbarService } from "@domain/shared/snackbar.service";
+import { User } from "@domain/auth/user.model";
+import { ok } from "@domain/shared/result.type";
+
+describe("ProfileEditInfoService", () => {
+  let service: ProfileEditInfoService;
+  let profileId: ReturnType<typeof signal<number | undefined>>;
+  let executeSaveProfile: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    profileId = signal<number | undefined>(42);
+    executeSaveProfile = vi.fn();
+
+    const values = {
+      firstName: "Иван",
+      lastName: "Иванов",
+      email: "ivan@example.com",
+      userType: 1,
+      birthday: "2000-01-01",
+      speciality: "Разработчик",
+      city: "Москва",
+      aboutMe: "",
+      avatar: null,
+      coverImageAddress: null,
+      phoneNumber: "",
+      skills: [],
+      education: [],
+      workExperience: [],
+      userLanguages: [],
+    };
+    const controls: Record<string, any> = Object.fromEntries(
+      Object.entries(values).map(([name, value]) => [
+        name,
+        {
+          value,
+          valid: true,
+          clearValidators: vi.fn(),
+          updateValueAndValidity: vi.fn(),
+        },
+      ]),
+    );
+    const form = {
+      value: values,
+      markAllAsTouched: vi.fn(),
+      updateValueAndValidity: vi.fn(),
+      get: vi.fn((name: string) => controls[name] ?? null),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        ProfileEditInfoService,
+        {
+          provide: ProfileFormService,
+          useValue: {
+            getForm: () => form,
+            profileId,
+            typeSpecific: { value: {} },
+            achievements: { value: [], length: 0 },
+          },
+        },
+        { provide: ActivatedRoute, useValue: { snapshot: { queryParams: {} } } },
+        { provide: NavigationService, useValue: { profileRedirect: vi.fn() } },
+        { provide: ProjectStepService, useValue: { setStepFromRoute: vi.fn() } },
+        { provide: NavService, useValue: { setNavTitle: vi.fn() } },
+        { provide: SaveProfileUseCase, useValue: { execute: executeSaveProfile } },
+        {
+          provide: ProfileInfoService,
+          useValue: { applyProfileUpdated: vi.fn() },
+        },
+        { provide: SnackbarService, useValue: { success: vi.fn() } },
+      ],
+    });
+    service = TestBed.inject(ProfileEditInfoService);
+  });
+
+  it("передает текущий profileId отдельно и не добавляет id в payload", () => {
+    executeSaveProfile.mockReturnValue(of(ok({ id: 42 } as User)));
+
+    service.saveProfile();
+
+    expect(executeSaveProfile).toHaveBeenCalledOnce();
+    expect(executeSaveProfile.mock.calls[0][0]).toBe(42);
+    expect(executeSaveProfile.mock.calls[0][1]).not.toHaveProperty("id");
+  });
+
+  it("не отправляет профиль без корректного profileId", () => {
+    profileId.set(undefined);
+
+    service.saveProfile();
+
+    expect(executeSaveProfile).not.toHaveBeenCalled();
+    expect(service.profileFormSubmitting$().status).toBe("failure");
+    expect(service.isModalErrorSkillsChoose()).toBe(true);
+  });
+});

--- a/projects/social_platform/src/app/api/profile/facades/edit/profile-edit-info.service.ts
+++ b/projects/social_platform/src/app/api/profile/facades/edit/profile-edit-info.service.ts
@@ -14,6 +14,7 @@ import { SaveProfileUseCase } from "@api/profile/use-cases/save-profile.use-case
 import { ProfileInfoService } from "../profile-info.service";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import { SnackbarService } from "@domain/shared/snackbar.service";
+import { INVALID_PROFILE_ID_MESSAGE, isValidProfileId } from "@domain/auth/profile-id";
 
 /** Фасад редактирования профиля: сбор формы, `SaveProfileUseCase`, раскрытие групп. */
 @Injectable()
@@ -138,6 +139,14 @@ export class ProfileEditInfoService {
       return;
     }
 
+    const profileId = this.profileId();
+    if (!isValidProfileId(profileId)) {
+      this.profileFormSubmitting$.set(failure("profile_edit_error"));
+      this.isModalErrorSkillsChoose.set(true);
+      this.isModalErrorSkillChooseText.set(INVALID_PROFILE_ID_MESSAGE);
+      return;
+    }
+
     this.profileFormSubmitting$.set(loading());
 
     const achievements = this.achievements.value.map((achievement: Achievement) => ({
@@ -157,7 +166,6 @@ export class ProfileEditInfoService {
 
     // Построение объекта профиля с только необходимыми полями
     const newProfile: any = {
-      id: this.profileId(),
       first_name: this.profileForm.value.firstName,
       last_name: this.profileForm.value.lastName,
       email: this.profileForm.value.email,
@@ -198,7 +206,7 @@ export class ProfileEditInfoService {
     }
 
     this.saveProfileUseCase
-      .execute(newProfile)
+      .execute(profileId, newProfile)
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(result => {
         if (!result.ok) {

--- a/projects/social_platform/src/app/api/profile/facades/edit/profile-form.service.ts
+++ b/projects/social_platform/src/app/api/profile/facades/edit/profile-form.service.ts
@@ -2,7 +2,7 @@
 
 import { DestroyRef, inject, Injectable, Injector, signal } from "@angular/core";
 import { FormArray, FormBuilder, FormControl, FormGroup, Validators } from "@angular/forms";
-import { concatMap, filter, map, Observable, skip, take } from "rxjs";
+import { concatMap, filter, map, Observable, skip, take, throwError } from "rxjs";
 import { yearRangeValidators } from "@utils/yearRangeValidators";
 import { User, UserRolesData } from "@domain/auth/user.model";
 import { Specialization } from "@domain/specializations/specialization.model";
@@ -15,6 +15,7 @@ import { languageLevelsList, languageNamesList } from "@core/consts/lists/langua
 import { AuthRepositoryPort } from "@domain/auth/ports/auth.repository.port";
 import { ProfileInfoService } from "../profile-info.service";
 import { takeUntilDestroyed, toObservable } from "@angular/core/rxjs-interop";
+import { INVALID_PROFILE_ID_MESSAGE, isValidProfileId } from "@domain/auth/profile-id";
 
 /** Реактивная форма профиля: построение `FormGroup`, справочники (роли, годы, образование), inline-специализации. */
 @Injectable({ providedIn: "root" })
@@ -364,8 +365,13 @@ export class ProfileFormService {
   }
 
   changeUserType(typeId: number): Observable<void> {
+    const profileId = this.profileId();
+    if (!isValidProfileId(profileId)) {
+      return throwError(() => new Error(INVALID_PROFILE_ID_MESSAGE));
+    }
+
     return this.authRepository
-      .updateProfile({
+      .updateProfile(profileId, {
         email: this.profileForm.value.email,
         firstName: this.profileForm.value.firstName,
         lastName: this.profileForm.value.lastName,

--- a/projects/social_platform/src/app/api/profile/use-cases/save-profile.use-case.spec.ts
+++ b/projects/social_platform/src/app/api/profile/use-cases/save-profile.use-case.spec.ts
@@ -25,9 +25,9 @@ describe("SaveProfileUseCase", () => {
     setup();
     repo.updateProfile.mockReturnValue(of(freshUser));
 
-    useCase.execute(command).subscribe();
+    useCase.execute(42, command).subscribe();
 
-    expect(repo.updateProfile).toHaveBeenCalledExactlyOnceWith(command);
+    expect(repo.updateProfile).toHaveBeenCalledExactlyOnceWith(42, command);
   });
 
   it("при успехе возвращает ok со профилем из updateProfile", () =>
@@ -35,7 +35,7 @@ describe("SaveProfileUseCase", () => {
       setup();
       repo.updateProfile.mockReturnValue(of(freshUser));
 
-      useCase.execute(command).subscribe(result => {
+      useCase.execute(42, command).subscribe(result => {
         expect(result.ok).toBe(true);
         if (result.ok) expect(result.value).toBe(freshUser);
         done();
@@ -48,7 +48,7 @@ describe("SaveProfileUseCase", () => {
       const boom = { error: { phone_number: ["плохой номер"] } };
       repo.updateProfile.mockReturnValue(throwError(() => boom));
 
-      useCase.execute(command).subscribe(result => {
+      useCase.execute(42, command).subscribe(result => {
         expect(result.ok).toBe(false);
         if (!result.ok) {
           expect(result.error.kind).toBe("profile_edit_error");

--- a/projects/social_platform/src/app/api/profile/use-cases/save-profile.use-case.ts
+++ b/projects/social_platform/src/app/api/profile/use-cases/save-profile.use-case.ts
@@ -14,8 +14,8 @@ export type SaveProfileResultError = { kind: "profile_edit_error"; cause?: SaveP
 export class SaveProfileUseCase {
   private readonly authRepository = inject(AuthRepositoryPort);
 
-  execute(command: UserInput): Observable<Result<User, SaveProfileResultError>> {
-    return this.authRepository.updateProfile(command).pipe(
+  execute(profileId: number, command: UserInput): Observable<Result<User, SaveProfileResultError>> {
+    return this.authRepository.updateProfile(profileId, command).pipe(
       map(profile => ok<User>(profile)),
       catchError(error =>
         of(fail<SaveProfileResultError>({ kind: "profile_edit_error", cause: error })),

--- a/projects/social_platform/src/app/domain/auth/ports/auth.repository.port.ts
+++ b/projects/social_platform/src/app/domain/auth/ports/auth.repository.port.ts
@@ -19,7 +19,7 @@ export abstract class AuthRepositoryPort {
   abstract resendEmail(email: string): Observable<User>;
   abstract fetchUser(id: number): Observable<User>;
   abstract fetchProfile(): Observable<User>;
-  abstract updateProfile(data: UserInput): Observable<User>;
+  abstract updateProfile(profileId: number, data: UserInput): Observable<User>;
   abstract updateOnboardingStage(stage: number | null, userId: number): Observable<User>;
   abstract updateAvatar(url: string, userId: number): Observable<User>;
   abstract fetchLeaderProjects(): Observable<ApiPagination<Project>>;

--- a/projects/social_platform/src/app/domain/auth/profile-id.ts
+++ b/projects/social_platform/src/app/domain/auth/profile-id.ts
@@ -1,0 +1,15 @@
+/**
+ * Сообщение для контролируемой ошибки при попытке обновить профиль без ID.
+ *
+ * @format
+ */
+
+export const INVALID_PROFILE_ID_MESSAGE =
+  "Не указан корректный идентификатор пользователя для обновления профиля";
+
+/**
+ * Проверяет, что идентификатор можно безопасно использовать в URL профиля.
+ */
+export function isValidProfileId(profileId: unknown): profileId is number {
+  return typeof profileId === "number" && Number.isInteger(profileId) && profileId > 0;
+}

--- a/projects/social_platform/src/app/infrastructure/adapters/auth/auth-http.adapter.spec.ts
+++ b/projects/social_platform/src/app/infrastructure/adapters/auth/auth-http.adapter.spec.ts
@@ -4,8 +4,9 @@ import { TestBed } from "@angular/core/testing";
 import { of } from "rxjs";
 import { ApiService, TokenService } from "@corelib";
 import { AuthHttpAdapter } from "./auth-http.adapter";
-import { User } from "@domain/auth/user.model";
+import { User, UserRaw } from "@domain/auth/user.model";
 import { LoginResponse, RegisterResponse } from "@core/lib/models/auth/http.model";
+import { INVALID_PROFILE_ID_MESSAGE } from "@domain/auth/profile-id";
 
 describe("AuthHttpAdapter", () => {
   let adapter: AuthHttpAdapter;
@@ -125,12 +126,30 @@ describe("AuthHttpAdapter", () => {
   it("saveProfile идёт в PATCH /auth/users/:id/ с частичными данными", () => {
     setup();
     api.patch.mockReturnValue(of({} as User));
-    const profile: Partial<User> = { id: 7, firstName: "A" };
+    const profile: Partial<UserRaw> = { id: 7, firstName: "A" };
 
-    adapter.saveProfile(profile).subscribe();
+    adapter.saveProfile(42, profile).subscribe();
 
-    expect(api.patch).toHaveBeenCalledExactlyOnceWith("/auth/users/7/", profile);
+    expect(api.patch).toHaveBeenCalledExactlyOnceWith("/auth/users/42/", profile);
   });
+
+  it.each([undefined, null, NaN, Infinity, 0, -1, 1.5])(
+    "saveProfile отклоняет некорректный profileId %s до HTTP-запроса",
+    profileId => {
+      setup();
+      let actualError: unknown;
+
+      adapter.saveProfile(profileId as number, { firstName: "A" }).subscribe({
+        error: error => {
+          actualError = error;
+        },
+      });
+
+      expect(api.patch).not.toHaveBeenCalled();
+      expect(actualError).toBeInstanceOf(Error);
+      expect((actualError as Error).message).toBe(INVALID_PROFILE_ID_MESSAGE);
+    },
+  );
 
   it("setOnboardingStage идёт в PUT /auth/users/:pid/set_onboarding_stage/", () => {
     setup();

--- a/projects/social_platform/src/app/infrastructure/adapters/auth/auth-http.adapter.ts
+++ b/projects/social_platform/src/app/infrastructure/adapters/auth/auth-http.adapter.ts
@@ -2,9 +2,10 @@
 
 import { inject, Injectable } from "@angular/core";
 import { ApiService, TokenService } from "@corelib";
-import { Observable } from "rxjs";
+import { Observable, throwError } from "rxjs";
 import { LoginResponse, RegisterResponse } from "@core/lib/models/auth/http.model";
 import { User, UserRaw } from "@domain/auth/user.model";
+import { INVALID_PROFILE_ID_MESSAGE, isValidProfileId } from "@domain/auth/profile-id";
 import { ProjectDto } from "../project/dto/project.dto";
 import { LoginCommand } from "@domain/auth/commands/login.command";
 import { RegisterCommand } from "@domain/auth/commands/register.command";
@@ -63,8 +64,13 @@ export class AuthHttpAdapter {
     return this.apiService.patch<User>(`${this.AUTH_USERS_URL}/${profileId}/`, { avatar: url });
   }
 
-  saveProfile(newProfile: Partial<UserRaw>): Observable<User> {
-    return this.apiService.patch<User>(`${this.AUTH_USERS_URL}/${newProfile.id}/`, newProfile);
+  /** Обновляет профиль по отдельно проверенному идентификатору маршрута. */
+  saveProfile(profileId: number, newProfile: Partial<UserRaw>): Observable<User> {
+    if (!isValidProfileId(profileId)) {
+      return throwError(() => new Error(INVALID_PROFILE_ID_MESSAGE));
+    }
+
+    return this.apiService.patch<User>(`${this.AUTH_USERS_URL}/${profileId}/`, newProfile);
   }
 
   setOnboardingStage(stage: number | null, profileId: number): Observable<User> {

--- a/projects/social_platform/src/app/infrastructure/repository/auth/auth.repository.spec.ts
+++ b/projects/social_platform/src/app/infrastructure/repository/auth/auth.repository.spec.ts
@@ -5,7 +5,7 @@ import { of } from "rxjs";
 import { AuthRepository } from "./auth.repository";
 import { AuthHttpAdapter } from "../../adapters/auth/auth-http.adapter";
 import { TokenService } from "@corelib";
-import { User } from "@domain/auth/user.model";
+import { User, UserInput } from "@domain/auth/user.model";
 import { LoginResponse, RegisterResponse } from "@core/lib/models/auth/http.model";
 import { ApiPagination } from "@domain/other/api-pagination.model";
 import { ProjectDto } from "../../adapters/project/dto/project.dto";
@@ -119,12 +119,21 @@ describe("AuthRepository", () => {
   it("updateProfile делегирует в adapter.saveProfile", () =>
     new Promise<void>(done => {
       setup();
-      const data = { id: 1, firstName: "A" } as never;
-      adapter.saveProfile.mockReturnValue(of({ id: 1, firstName: "A" } as User));
+      const data = {
+        firstName: "A",
+        personal: { city: "Москва" },
+      } as UserInput;
+      adapter.saveProfile.mockReturnValue(
+        of({ id: 42, firstName: "A", city: "Москва" } as unknown as User),
+      );
 
-      repository.updateProfile(data).subscribe(profile => {
-        expect(adapter.saveProfile).toHaveBeenCalledExactlyOnceWith(data);
+      repository.updateProfile(42, data).subscribe(profile => {
+        expect(adapter.saveProfile).toHaveBeenCalledExactlyOnceWith(42, {
+          firstName: "A",
+          city: "Москва",
+        });
         expect(profile).toBeInstanceOf(User);
+        expect(profile.personal.city).toBe("Москва");
         done();
       });
     }));

--- a/projects/social_platform/src/app/infrastructure/repository/auth/auth.repository.ts
+++ b/projects/social_platform/src/app/infrastructure/repository/auth/auth.repository.ts
@@ -60,9 +60,9 @@ export class AuthRepository implements AuthRepositoryPort {
     return this.authAdapter.getProfile().pipe(map(user => userFromRaw(user)));
   }
 
-  updateProfile(data: UserInput): Observable<User> {
+  updateProfile(profileId: number, data: UserInput): Observable<User> {
     const rawData = userToRaw(data);
-    return this.authAdapter.saveProfile(rawData).pipe(map(user => userFromRaw(user)));
+    return this.authAdapter.saveProfile(profileId, rawData).pipe(map(user => userFromRaw(user)));
   }
 
   updateOnboardingStage(stage: number | null, userId: number): Observable<User> {


### PR DESCRIPTION
## Что изменено

- Убран автоматический переход в поэтапный onboarding после подтверждения email.
- Пользователи с любым значением onboardingStage сразу попадают в рабочую часть платформы.
- Сохранена проверка verificationDate и существующая verification modal.
- Исправлено обновление профиля: ID пользователя передается отдельно и больше не извлекается из частичного payload.
- Редактирование профиля продолжает работать через PATCH /auth/users/<id>/.

## Что не изменялось

- Backend.
- React frontend.
- API регистрации и подтверждения email.
- Маршруты и компоненты старого onboarding.
- GitHub workflows и deploy-конфигурация.
- Другие изменения из dev.

## Проверки

- 848/848 тестов успешно.
- lint успешно, 0 ошибок.
- production build успешно.
- git diff --check успешно.
- Все 21 измененный файл проходят Prettier.
- Ветка основана непосредственно на актуальном origin/master.

## Коммиты

- Fix profile update identifier
- Disable mandatory onboarding